### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,8 @@ GEM
       i18n (~> 0.5)
     font-awesome-sass (4.1.0)
       sass (~> 3.2)
+    fuzzily (0.3.2)
+      activerecord (>= 2.3.17)
     haml (4.0.5)
       tilt
     hike (1.2.3)
@@ -66,7 +68,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.1)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -149,6 +151,7 @@ DEPENDENCIES
   execjs
   faker
   font-awesome-sass
+  fuzzily
   haml
   impressionist
   jbuilder


### PR DESCRIPTION
We have to use a more recent version of the `libv8` gem, because of incompatibilities of a version below `3.16.4.4` with OS X Yosemite. `bundle install` on OS X should work again after this pull.
