### PR TITLE
Remove transparent border in navigation menu

### DIFF
--- a/vendor/assets/stylesheets/style.css
+++ b/vendor/assets/stylesheets/style.css
@@ -4581,7 +4581,6 @@ input[type="button"].btn-block {
     position: relative;
     min-height: 50px;
     margin-bottom: 20px;
-    border: 1px solid transparent;
 }
 
 .navbar:before, .navbar:after {


### PR DESCRIPTION
Title says it :) That annoying piece of whitespace is finally gone!

Note: although the fix is simple, it _does_ modify a vendored stylesheet. I don't know if we still receive updates from those people, but if we do, it would be wiser to discard this fix and to override it in our own stylesheets.
