### PR TITLE
Add admin user to db seeds.

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,35 +1,36 @@
 class Admin < ActiveRecord::Base
   has_one :user, as: :credentials
-  
+
   attr_accessor :email
   attr_accessor :password
   attr_accessor :password_confirmation
-  
+
   def name
     if infix.blank?
       return "#{self.first_name} #{self.last_name}"
     end
-    
+
     return "#{self.first_name} #{self.infix} #{self.last_name}"
   end
-  
+
   def sender
     if infix.blank?
       return "#{self.first_name} #{self.last_name} <#{self.user.email}>"
     end
-    
+
     return "#{self.first_name} #{self.infix} #{self.last_name} <#{self.user.email}>"
   end
-  
+
+  # We need to create a new user. This record will serve as the credentials for
+  # logging in for this user. Admin users are automatically confirmed.
   after_save do
     credentials = User.new(
       email:                  email,
       password:               password,
       password_confirmation:  password_confirmation,
-      
-      credentials: self
+      confirmed_at:           Time.now,
+      credentials:            self
     )
-    
     credentials.save
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,6 +94,12 @@ Study.create(
   masters:        true
 )
 
+Admin.create(
+  email:                 "admin@example.com",
+  password:              "adminadmin",
+  password_confirmation: "adminadmin"
+)
+
 # Suppress exception for the unique key [member, activity]
 suppress(Exception) do
   200.times do


### PR DESCRIPTION
The database seeds now automatically create an admin user so new contributors can more easily check out the system.
- Login with admin@example.com.
- Default password is `adminadmin`.
- Development setup is now a bit easier.

This has one consequence: admin users don't need to confirm their email address, since their confirmed at time is automatically set to Time.now. I guess this won't be a problem, since these users need to be added manually anyway.

_Also removes some whitespace._
