### PR TITLE
Change path of studystatus script

### DIFF
--- a/lib/tasks/studystatus.rake
+++ b/lib/tasks/studystatus.rake
@@ -17,7 +17,7 @@ namespace :studystatus do
   desc "Finds study progress for a member and updates the DB"
   task :update, [:username, :password, :student_id] => :environment do |t, args|
 
-    Open3.popen3("/usr/local/bin/studystatus",
+    Open3.popen3("/usr/local/bin/studystatus.py",
                  "--username", args[:username],
                  "--password", args[:password]) do |i, o, e, t|
 
@@ -33,7 +33,7 @@ namespace :studystatus do
   desc "Finds study progress for all members and updates the DB"
   task :update_all, [:username, :password] => :environment do |t, args|
     # TODO: handle empty username and password
-    Open3.popen3("/usr/local/bin/studystatus",
+    Open3.popen3("/usr/local/bin/studystatus.py",
                  "--username", args[:username],
                  "--password", args[:password]) do |i, o, e, t|
 


### PR DESCRIPTION
This should fix the studystatus errors for now. The path of the script is hardcoded in the Rake task, which isn't ideal.

On the server `/usr/bin/studystatus` is currently a bash script that calls the rake task. The rake task then called the script again, leading to an infinite loop and breaking stuff.

This updates the path to the right python script on the server. Ideally, this should be read from a config in the future.
