### PR TITLE
Change begin- and end-dates for activities to datetimes

### DIFF
--- a/app/views/admin/activities/index.html.haml
+++ b/app/views/admin/activities/index.html.haml
@@ -72,13 +72,15 @@
 
               .form-group
                 .row
-                  .col-md-4
+                  .col-md-6
                     = label(:activity, :start_date)
-                    = f.date_field :start_date, :value => @activity.start_date, :class => 'form-control'
-                  .col-md-4
+                    = f.datetime_field :start_date, :value => @activity.start_date, :class => 'form-control', :type => 'datetime-local'
+                  .col-md-6
                     = label(:activity, :end_date)
-                    = f.date_field :end_date, :value => @activity.end_date, :class => 'form-control'
-                  .col-md-4
+                    = f.datetime_field :end_date, :value => @activity.end_date, :class => 'form-control', :type => 'datetime-local'
+              .form-group
+                .row
+                  .col-md-12
                     = label(:activity, :organized_by)
                     .ui-select
                       = f.select :organized_by, options_for_select(Group.has_members.order(:category, :name).map{ |group| [group.name, group.id] }, @activity.organized_by), :include_blank => '-'

--- a/app/views/admin/activities/show.html.haml
+++ b/app/views/admin/activities/show.html.haml
@@ -68,13 +68,15 @@
 
               .form-group
                 .row
-                  .col-md-4
+                  .col-md-6
                     = label(:activity, :start_date)
-                    = f.date_field :start_date, :value => @activity.start_date, :class => 'form-control'
-                  .col-md-4
+                    = f.datetime_field :start_date, :value => I18n.l(@activity.start_date, :format => :form), :class => 'form-control', :type => 'datetime-local'
+                  .col-md-6
                     = label(:activity, :end_date)
-                    = f.date_field :end_date, :value => @activity.end_date, :class => 'form-control'
-                  .col-md-4
+                    = f.datetime_field :end_date, :value => (I18n.l(@activity.end_date, :format => :form) unless @activity.end_date.nil?), :class => 'form-control', :type => 'datetime-local'
+              .form-group
+                .row
+                  .col-md-12
                     = label(:activity, :organized_by)
                     .ui-select
                       = f.select :organized_by, options_for_select(Group.has_members.order(:category, :name).map{ |group| [group.name, group.id] }, @activity.organized_by), :include_blank => '-'

--- a/app/views/api/activities/index.rabl
+++ b/app/views/api/activities/index.rabl
@@ -1,6 +1,22 @@
 collection @activities
 
-attributes :name, :start_date, :end_date
+attributes :name
+
+node :start_date do |activity|
+  activity.start_date.strftime('%Y-%m-%d')
+end
+
+node :start_time do |activity|
+  activity.start_date.strftime('%H:%M')
+end
+
+node :end_date do |activity|
+  activity.end_date.strftime('%Y-%m-%d') unless activity.end_date.nil?
+end
+
+node :end_time do |activity|
+  activity.end_date.strftime('%H:%M') unless activity.end_date.nil?
+end
 
 if Authorization._client.include?('activities-read')
   attributes :id, :description, :price

--- a/app/views/api/activities/show.rabl
+++ b/app/views/api/activities/show.rabl
@@ -1,5 +1,21 @@
 object @activity
-attributes :id, :name, :description, :start_date, :end_date, :price
+attributes :id, :name, :description, :price
+
+node :start_date do |activity|
+  activity.start_date.strftime('%Y-%m-%d')
+end
+
+node :start_time do |activity|
+  activity.start_date.strftime('%H:%M')
+end
+
+node :end_date do |activity|
+  activity.end_date.strftime('%Y-%m-%d') unless activity.end_date.nil?
+end
+
+node :end_time do |activity|
+  activity.end_date.strftime('%H:%M') unless activity.end_date.nil?
+end
 
 glue :group do
   attribute :name => :group

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -11,6 +11,8 @@ nl:
   time:
     formats:
       default: "%d-%m-%Y %H:%M"
+      form: "%Y-%m-%dT%H:%M"
+      day_month: "%d %B"
       short: "%H:%M"
 
   activerecord:

--- a/db/migrate/20160505145015_activity_datetimes.rb
+++ b/db/migrate/20160505145015_activity_datetimes.rb
@@ -1,0 +1,6 @@
+class ActivityDatetimes < ActiveRecord::Migration
+	def change
+		change_column :activities, :start_date, :datetime
+		change_column :activities, :end_date, :datetime
+	end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160402084056) do
+ActiveRecord::Schema.define(version: 20160505145015) do
 
   create_table "activities", force: :cascade do |t|
     t.string   "name",                limit: 255
-    t.date     "start_date"
-    t.date     "end_date"
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.decimal  "price",                             precision: 6, scale: 2
     t.text     "comments",            limit: 65535
     t.datetime "created_at"


### PR DESCRIPTION
Roadmap item 20, does not directly fix an issue.
### Changes proposed in this pull request:
- [ ] `Activity.begin_date` and `end_date` columns converted to datetime
- [ ] Activity forms updated to show new datetimepicker
- [ ] API views updated to add separate start_time and end_time nodes

@svsticky/it-crowd

Open questions:
- All times of existing events will default to either midnight or 02:00, depending on
  timezone. Is this an issue / can we do anything about it?
- Is a datetime the correct solution if we sometimes need to show the date and time separately?
