### PR TITLE
Replaced 'request_entity_too_large' with 'payload_too_large'

### DIFF
--- a/app/controllers/admin/checkout_products_controller.rb
+++ b/app/controllers/admin/checkout_products_controller.rb
@@ -66,7 +66,7 @@ class Admin::CheckoutProductsController < ApplicationController
     begin
       transaction.save
     rescue ActiveRecord::RecordNotSaved => exception
-      render :status => :request_entity_too_large, :json => exception.message
+      render :status => :payload_too_large, :json => exception.message
       return
     rescue ActiveRecord::RecordInvalid
       render :status => :bad_request, :json => exception.message

--- a/app/controllers/api/checkout_controller.rb
+++ b/app/controllers/api/checkout_controller.rb
@@ -35,7 +35,7 @@ class Api::CheckoutController < ApplicationController
 
       head :bad_request and return if error.message == 'empty_items'
 
-      render :status => :request_entity_too_large, :json => {
+      render :status => :payload_too_large, :json => {
         message: 'insufficient funds',
         balance: card.checkout_balance.balance,
         items: params[:items].to_a,


### PR DESCRIPTION
### Fixes

[Issue 195](https://github.com/svsticky/constipated-koala/issues/195)
A proper 413 status will be returned instead of 500.
### Changes proposed in this pull request:
- Replaced 'request_entity_too_large' with 'payload_too_large'

@svsticky/it-crowd
