### PR TITLE
Add translation of remaining strings in interface

### DIFF
--- a/app/views/admin/apps/products.html.haml
+++ b/app/views/admin/apps/products.html.haml
@@ -43,20 +43,20 @@
                 .form-group.thumb
                   .row
                     .col-md-8
-                      = label(:checkout_product, :name)
+                      = label(:checkout_product, I18n.t( :name, scope: 'activerecord.attributes.checkout_product' ))
                       = f.text_field :name, :value => @product.name, :class => 'form-control', :disabled => @product.has_children?
                     .col-md-4
-                      = label(:checkout_product, :price)
+                      = label(:checkout_product, I18n.t( :price, scope: 'activerecord.attributes.checkout_product' ))
                       = f.text_field :price, :value => number_to_currency(@product.price, :unit => ''), :class => 'form-control', :disabled => @product.has_children?
 
                 .form-group.thumb
                   .row
                     .col-md-4
-                      = label(:checkout_product, :category)
+                      = label(:checkout_product, I18n.t( :category, scope: 'activerecord.attributes.checkout_product' ))
                       .ui-select
                         = f.select :category, options_for_select( CheckoutProduct.categories.map{ |name, id| [I18n.t(name, scope: 'activerecord.attributes.checkout_product.categories'), name] }, @product.category )
                     .col-md-8
-                      = label(:checkout_product, :image)
+                      = label(:checkout_product, I18n.t( :image, scope: 'activerecord.attributes.checkout_product' ))
                       .input-group
                         %input#output.form-control{ :readonly => ''}
 
@@ -73,7 +73,7 @@
                 = link_to 'Annuleren', checkout_products_path, { :class => 'button btn btn-default' }
 
                 .pull-right
-                  = label(:checkout_product, :active)
+                  = label(:checkout_product, I18n.t( :active, scope: 'activerecord.attributes.checkout_product' ))
                   = f.check_box :active, :checked => @product.active, :disabled => @product.has_children?
 
               %table.table.table-striped.table-linked#products
@@ -107,20 +107,20 @@
                 .form-group
                   .row
                     .col-md-8
-                      = label(:checkout_product, :name)
+                      = label(:checkout_product, I18n.t( :name, scope: 'activerecord.attributes.checkout_product' ))
                       = f.text_field :name, :value => @new.name, :class => 'form-control'
                     .col-md-4
-                      = label(:checkout_product, :price)
+                      = label(:checkout_product, I18n.t( :price, scope: 'activerecord.attributes.checkout_product' ))
                       = f.text_field :price, :value => number_to_currency(@new.price, :unit => ''), :class => 'form-control'
 
                 .form-group
                   .row
                     .col-md-4
-                      = label(:checkout_product, :category)
+                      = label(:checkout_product, I18n.t( :category, scope: 'activerecord.attributes.checkout_product' ))
                       .ui-select
                         = f.select :category, options_for_select( CheckoutProduct.categories.map{ |name, id| [I18n.t(name, scope: 'activerecord.attributes.checkout_product.categories'), name] }, @new.category )
                     .col-md-8
-                      = label(:checkout_product, :image)
+                      = label(:checkout_product, I18n.t( :image, scope: 'activerecord.attributes.checkout_product' ))
                       .input-group
                         %input#output.form-control{ :readonly => ''}
 

--- a/app/views/admin/groups/index.html.haml
+++ b/app/views/admin/groups/index.html.haml
@@ -101,15 +101,15 @@
                 .form-group
                   .row
                     .col-md-8
-                      = f.label :name
+                      = f.label I18n.t( :name, scope: 'activerecord.attributes.group' )
                       = f.text_field :name, :value => @new.name, :class => 'form-control'
                     .col-md-4
-                      = label(:group, :category)
+                      = label(:group, I18n.t( :category, scope: 'activerecord.attributes.group' ))
                       .ui-select
                         = f.select :category, options_for_select( Group.categories.map{ |name, id| [I18n.t(name, scope: 'activerecord.attributes.group.categories'), name] }, selected: @new.category, disabled: ['board'] )
 
                 .form-group
-                  = label(:group, :comments)
+                  = label(:group, I18n.t( :comments, scope: 'activerecord.attributes.group' ))
                   = f.text_area :comments, :value => @new.comments, :class => 'form-control', :rows => 5
 
                 %button.btn.btn-success.wait{type: 'submit'} Opslaan

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -88,7 +88,7 @@ nl:
         price: Prijs
         image: Afbeelding
         category: Categorie
-        active: Is actief
+        active: Actief
 
         categories:
           beverage: Drinken


### PR DESCRIPTION
The couple strings that were still hardcoded, and therefore English, are now being referred to the translation dictionary. 

That means they can be displayed in Dutch, consistent with the rest of the interface.
