### PR TITLE
Remove HTTP security headers in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,4 +85,5 @@ Rails.application.configure do
       :original => :private
     }
   }
+  config.action_dispatch.default_headers.clear
 end


### PR DESCRIPTION
HTTP headers are added in production by the reverse proxy, nginx, so I have disabled Rails from adding them in the production environment. Otherwise we end up with duplicated headers.

Concerns the following headers:

- 'X-Frame-Options' => 'SAMEORIGIN'
- 'X-XSS-Protection' => '1; mode=block'
- 'X-Content-Type-Options' => 'nosniff'