### PR TITLE
Overwritten default method to add logging for failed login attempts

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,3 +1,18 @@
 class Users::SessionsController < Devise::SessionsController
   skip_before_action :authenticate_admin!, only: [:create, :destroy]
+
+  # NOTE overwrite create method, once a user is authenticated we can verify
+  # it has worked, othersie we can create a fatal log rule.
+  def create
+    begin
+
+      # perform default create from devise sessioncontroller
+      super
+    ensure
+
+      # check if authentication succeeded, otherwise log failed attempt
+      return unless current_user.nil?
+      logger.fatal "[#{Time.zone.now}] failed login attempt; #{request.remote_ip}; #{request.filtered_parameters['user']['email']}"
+    end
+  end
 end


### PR DESCRIPTION
### Fixes #230 

### Changes proposed in this pull request:
- overwritten default function to add an ensure statement
- log rule created if login failed in ensure statement
