### PR TITLE
fix bug attendees of masters activities

### DIFF
--- a/app/controllers/users/enrollments_controller.rb
+++ b/app/controllers/users/enrollments_controller.rb
@@ -128,7 +128,7 @@ class Users::EnrollmentsController < ApplicationController
 
     # Reservist if no spots left
     if !@activity.participant_limit.nil? &&
-      @activity.participants.count >= @activity.participant_limit
+      @activity.attendees.count >= @activity.participant_limit
 
       @new_enrollment = Participant.new(
         member_id: @member.id,

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -229,12 +229,13 @@ class Activity < ActiveRecord::Base
     # Helper method for use in displaying the remaining spots etc. Used both in API and in the enrollments view.
     return "" unless self.is_enrollable
 
+    # Use attendees.count instead of participants.count because in case of masters activities there can be reservists even if activity isn't full.
     if self.participant_limit
-      return "VOL!" if self.participants.count >= self.participant_limit
-      return "#{self.participants.count}/#{self.participant_limit}"
+      return "VOL!" if self.attendees.count >= self.participant_limit
+      return "#{self.attendees.count}/#{self.participant_limit}"
     end
 
-    return "#{self.participants.count}"
+    return "#{self.attendees.count}"
   end
 
 end

--- a/app/views/layouts/activity/users/_view.html.haml
+++ b/app/views/layouts/activity/users/_view.html.haml
@@ -88,7 +88,7 @@
         - elsif @current_member.reservist_activities.ids.include? activity.id
           - button_text = 'Uitschrijven Reservelijst'
           - button_class = 'btn-warning'
-        - elsif (activity.participant_limit != nil && activity.participant_limit <= activity.participants.count) || (activity.is_masters? && !@current_member.is_masters?)
+        - elsif (activity.participant_limit != nil && activity.participant_limit <= activity.attendees.count) || (activity.is_masters? && !@current_member.is_masters?)
           - button_text = 'Inschrijven Reservelijst'
           - button_class = 'btn-warning-sat'
         - else


### PR DESCRIPTION
### Fixes bug participant count

### Changes proposed in this pull request:
- Bug meant that participant_limit was compared with participant.count instead of attendees.count, which was okay so long as there were no masters activities, but is not okay now that there can be participants that are reservists while the activity is not full.
This has been fixed.