### PR TITLE
Prevent members from changing their name

### DIFF
--- a/app/assets/stylesheets/members/home.css
+++ b/app/assets/stylesheets/members/home.css
@@ -183,3 +183,10 @@ div.clickable > .panel:hover {
 #header .menu-button {
   left: 0;
 }
+
+.form-control-disabled {
+  cursor: not-allowed;
+  background-color: #eeeeee;
+  opacity: 1;
+  font-weight: normal;
+}

--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -111,10 +111,7 @@ class Members::HomeController < MembersController
 
   private
   def member_post_params
-    params.require(:member).permit(:first_name,
-                                   :infix,
-                                   :last_name,
-                                   :address,
+    params.require(:member).permit(:address,
                                    :house_number,
                                    :postal_code,
                                    :city,

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -23,13 +23,13 @@
           .row
             .col-md-5
               %label{for: ''} Voornaam
-              = f.text_field :first_name, :value => @member.first_name, :class => 'form-control'
+              = f.label :first_name, :value => @member.first_name, :class => 'form-control form-control-disabled'
             .col-md-2
               %label{for: ''} Tussenvoegsel
-              = f.text_field :infix, :value => @member.infix, :class => 'form-control'
+              = f.label :infix, :value => @member.infix, :class => 'form-control form-control-disabled'
             .col-md-5
               %label{for: ''} Achternaam
-              = f.text_field :last_name, :value => @member.last_name, :class => 'form-control'
+              = f.label :last_name, :value => @member.last_name, :class => 'form-control form-control-disabled'
 
         .form-group
           .row
@@ -39,7 +39,7 @@
                 = f.select :gender, options_for_select([["MAN", "m"], ["VROUW", "f"]], @member.gender)
             .col-md-6
               %label{for: ''} Geboortedatum
-              = f.label :birth_date, :value => @member.birth_date, :class => 'form-control birthdate'
+              = f.label :birth_date, :value => @member.birth_date, :class => 'form-control form-control-disabled birthdate'
 
         .form-group
           .row


### PR DESCRIPTION
- Remove form inputs and replace with labels
- Discard attributes if still submitted
- Add new .form-control-disabled class and apply to birthdate and labels

Fixes #258