### PR TITLE
Fix a styling error occurring in Firefox

### DIFF
--- a/app/assets/stylesheets/admin/apps.css
+++ b/app/assets/stylesheets/admin/apps.css
@@ -70,7 +70,7 @@ div#credit.input-group > .input-symbol > input {
   width: 80px;
 }
 
-div#credit.input-group > select {
+div#credit.input-group select {
   background-color: white;
   height: 32px;
 }

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -78,11 +78,15 @@
                     %span &euro;
                     %input#amount{ :type => 'number', :placeholder => number_to_currency(@member.checkout_cards.first.checkout_balance.balance, :unit => '') }
 
-                  %select#payment_method{ :required => true }
-                    %option{:value => "Gepind"}= "Gepind"
-                    %option{:value => "Contant"}= "Contant"
-                    %option{:value => "", :selected => "selected" }= "-"
-                    %option{:value => "Verkoop"}= "Verkoop"
+                  <!-- Containing this selector in a div fixes an
+                  overflow in Firefox, that doesn't occur in
+                  Chrome. See #203. -->
+                  #selector-container
+                    %select#payment_method{ :required => true }
+                      %option{:value => "Gepind"}= "Gepind"
+                      %option{:value => "Contant"}= "Contant"
+                      %option{:value => "", :selected => "selected" }= "-"
+                      %option{:value => "Verkoop"}= "Verkoop"
 
                   %span.input-group-btn
                     %button.btn.btn-warning opwaarderen


### PR DESCRIPTION
See #203

When as admin looking at a member with a checkout card in Firefox, the
payment method selection would overflow to the next line. This wouldn't
occur in Chrome/Chromium. After experimenting, I found out that
containing the select input in another div would fix this problem
without any regressions noticeable to me. But why this works I don't
know.

To make this fix work while retaining the same styling for this select
input, I generalized the background color and height scss entry for any
direct childs of a div#credit.input-group to any childs (so also further
descendants) of div#credit.input-group. As far as I know this doesn't
cause any changes apart from this intended change, since there is only
one element with the id credit and the class input-group, and it doesn't
have any other childs which this affects adversely.