### PR TITLE
Fix finished activities showing up in activity API

### DIFF
--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -8,6 +8,7 @@ class Api::ActivitiesController < ApiController
     else
       @activities = Activity.where('(end_date IS NULL AND start_date >= ?) OR end_date >= ?', Date.today, Date.today).order(:start_date).where(is_viewable: true)
       @activities.limit!(params[:limit]).offset(params[:offset] ||= 0) if params[:limit].present?
+      @activities = @activities.select {|act| !act.ended?}
     end
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -141,9 +141,9 @@ class Activity < ApplicationRecord
 
   def self.combine_dt(d, t)
     if t
-      DateTime.new(d.year, d.month, d.day, t.hour, t.min, t.sec)
+      Time.zone.local(d.year, d.month, d.day, t.hour, t.min, t.sec)
     elsif d
-      DateTime.new(d.year, d.month, d.day)
+      Time.zone.local(d.year, d.month, d.day)
     else
       nil
     end
@@ -239,6 +239,6 @@ class Activity < ApplicationRecord
   end
 
   def ended?
-    (self.end_time and self.end < DateTime.now) or (self.end_time.nil? and self.start < DateTime.now)
+    (self.end_time and self.end < Time.zone.now) or (self.end_time.nil? and self.start < Time.zone.now)
   end
 end


### PR DESCRIPTION
The activity API no longer shows activities that finished earlier today.

Activity.ended? did not behave as expected due to timezones, but this
should be fixed now.