### PR TITLE
Deny enrollment for non-students

### DIFF
--- a/app/controllers/members/participants_controller.rb
+++ b/app/controllers/members/participants_controller.rb
@@ -26,6 +26,16 @@ class Members::ParticipantsController < MembersController
       return
     end
 
+    # Deny members that don't study
+    if !@member.enrolled_in_study?
+      render status: :failed_dependency, json: {
+        message: I18n.t(:participant_no_student, scope: @activity_errors_scope),
+        participant_limit: @activity.participant_limit,
+        participant_count: @activity.participants.count
+      }
+      return
+    end
+
     # Deny suspended members
     if Tag.exists?(member: @member, name: Tag.names[:suspended])
       render status: :failed_dependency, json: {

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -320,6 +320,10 @@ class Member < ApplicationRecord
     return 18.years.ago >= self.birth_date
   end
 
+  def enrolled_in_study?
+    return Education.exists?(member: self, status: Education.statuses[:active])
+  end
+
   def unpaid_activities
       # All participants who will receive payment reminders
       self.participants.joins(:activity).where('

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,6 +189,7 @@ en:
           participant_suspended: You have been suspended. Contact the board of Sticky
           participant_no_masters: You are not a masters student. This is a masters-only activity.
           participant_no_freshman: You are not a freshman student. This is a freshmans-only activity.
+          participant_no_student: You are not enrolled in a study. This activity is for students only
           participant_limit_reached: '%{activity} is full!'
           participant_underage: This activity is for adults only ;)
           participant_notes_not_filled: This activity requires extra information, please fill this in before enrolling

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -223,6 +223,7 @@ nl:
           participant_suspended: Je bent geschorst. Neem contact op met het bestuur van Sticky
           participant_no_masters: Je bent geen masters student. Deze activiteit is een masters-activiteit.
           participant_no_freshman: Je bent geen eerstejaars student. Dit is een eerstejaarsactiviteit.
+          participant_no_student: Je bent niet ingeschreven bij een studie. Deze activiteit is alleen voor studenten
           participant_limit_reached: '%{activity} zit vol!'
           participant_underage: Deze activiteit is alleen voor grote mensen ;)
           participant_notes_not_filled: Deze activiteit vereist extra informatie, vul dit in voor dat je je inschrijft


### PR DESCRIPTION
So far when a member enrolls for an activity, there is no check on study status
except for freshmen or masters. Now, a check is added to see if a member is
currently actively enrolled in a study. If not, enrollment will be denied.