### PR TITLE
Exclude reservists from list of defaulters

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -10,8 +10,8 @@ class Admin::HomeController < ApplicationController
 
     @unpayed = Participant.where(:reservist => false, :paid => false).sum(:price) + Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity).where('activities.price IS NOT NULL').sum('activities.price')
 
-    @defaulters = Participant.where(:paid => false).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum(:price).merge( \
-      Participant.where(:paid => false, :price => nil).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum('activities.price ')
+    @defaulters = Participant.where(:reservist => false, :paid => false).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum(:price).merge( \
+      Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum('activities.price ')
     ) { |k, sum_a, sum_b| sum_a + sum_b }.sort_by { |_, sum| -sum }.map { |k, v| [Member.where(:id => k).select(:id, :first_name, :infix, :last_name).first, v] }.take(12).delete_if { |k, v| v == 0 }
   end
 end


### PR DESCRIPTION
Because obviously you don't owe any money for an activity when you weren't actually enrolled in it.

Fixes #315.