### PR TITLE
Don't show 'uitschrijfdeadline' when not enrollabe

### DIFF
--- a/app/views/members/activities/partials/_view.html.haml
+++ b/app/views/members/activities/partials/_view.html.haml
@@ -44,7 +44,7 @@
         %strong Locatie:
         = activity.location
         <br/>
-      - if !activity.unenroll_date.nil?
+      - if !activity.unenroll_date.nil? && activity.is_enrollable?
         %strong Uitschrijfdeadline:
         %span.activity-unenroll
           = activity.unenroll_date.strftime("%d/%m/%Y")


### PR DESCRIPTION
Quick hotfix because people have been saying it doesn't make sense to show a deadline to unenroll when you can't enroll in the first place.