### PR TITLE
Add extra check to Mongoose funds add number #279

### DIFF
--- a/app/models/ideal_transaction.rb
+++ b/app/models/ideal_transaction.rb
@@ -5,7 +5,7 @@ class IdealTransaction < ApplicationRecord
 
   attr_accessor :issuer, :mollie_uri, :message
   validates :description, presence: true
-  validates :amount, presence: true
+  validates :amount, presence: true, numericality: true
   validates :status, presence: true
 
   belongs_to :member


### PR DESCRIPTION
Although #279 seemed to have been fixed already, I added an additional
check just to add some more robustness to this system. This should be
able to close the issue.