### PR TITLE
Fix bugs in member's email validation regex

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -11,7 +11,7 @@ class Member < ApplicationRecord
   validates :postal_code, presence: true
   validates :city, presence: true
   validates :phone_number, presence: true, format: { with: /(^\+[0-9]{2}|^\+[0-9]{2}\(0\)|^\(\+[0-9]{2}\)\(0\)|^00[0-9]{2}|^0)([0-9]{9}$|[0-9\-\s]{10}$)/, multiline: true }
-  validates :email, presence: true, uniqueness: { :case_sensitive => false }, format: { with: /[A-Za-z0-9.+-_]+@(?![A-Za-z]*\.?uu\.nl)([A-Za-z0-9.+-_]+\.[A-Za-z.]+)/ }
+  validates :email, presence: true, uniqueness: { :case_sensitive => false }, format: { with: /\A.+@(?!(.+\.)*uu\.nl\z).+\..+\z/i }
   validates :gender, presence: true, inclusion: { in: %w(m f) }
 
   # An attr_accessor is basically a variable attached to the model but not stored in the database


### PR DESCRIPTION
The current regex that validates the email address of a member blocks emails like:
- example@exampleuu.nl
- example@uu.nl.example

I fixed this, and also simplified the entire regex as much as possible, because ideally [regexes should not be used to validate emails at all](https://davidcel.is/posts/stop-validating-email-addresses-with-regex/).

If we do want to keep it as strict, this one just fixes the bugs: `/\A[\w.+-]+@(?!(\w+\.)*uu\.nl\z)[\w.+-]+\.[A-Za-z]+\z/i`