### PR TITLE
Show a member's transactions even if there's no card

### DIFF
--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -67,7 +67,7 @@
               = link_to 'Back', :back, { :class => 'button btn btn-default' }
               = link_to 'Edit', edit_member_path(@member.id), { :class => 'button btn btn-warning' }
 
-          - if @member.checkout_cards.length > 0
+          - if @transactions.length > 0
             .panel.panel-default
               .panel-heading.input
                 %i.fa.fa-fw.fa-shopping-cart
@@ -76,7 +76,7 @@
                 .input-group#credit{ :data => { 'member_id' => @member.id }}
                   .input-symbol
                     %span &euro;
-                    %input#amount{ :type => 'number', :placeholder => number_to_currency(@member.checkout_cards.first.checkout_balance.balance, :unit => '') }
+                    %input#amount{ :type => 'number', :placeholder => number_to_currency(@member.checkout_balance.balance, :unit => '') }
 
                   <!-- Containing this selector in a div fixes an
                   overflow in Firefox, that doesn't occur in


### PR DESCRIPTION
When there are >0 Checkout transactions tied to a member, like a top-up, but no cards yet, the transactions in the admin's member detail view would be hidden.

Therefore I changed the check to check for transactions, instead of cards.