### PR TITLE
WIP: Add banner for GDPR notice

### DIFF
--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -18,6 +18,9 @@
         %i.fa.fa-fw.fa-user
         = I18n.t('members.home.edit.general_data')
       .panel-body
+        .alert.alert-info
+          %i.fa.fa-gavel
+          = I18n.t 'members.home.edit.gdpr_rights'
         .form-group
           .row
             .col-md-5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,6 +443,7 @@ en:
     home:
       edit:
         general_data: General
+        gdpr_rights: "Yo rights and shit you know it"
       index:
         edit_profile: "Edit profile"
         outstanding_payments: "Outstanding payments"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -505,6 +505,7 @@ nl:
     home:
       edit:
         general_data: "Algemene gegevens"
+        gdpr_rights: "Yo rechten en shit je weet toch"
       index:
         edit_profile: "Gegevens bewerken"
         outstanding_payments: "Openstaande betalingen"


### PR DESCRIPTION
Adds a banner in the member's edit form that can hold the notice about the right to be forgotten and other GDPR stuff.
Do we have a text for the notice already?

The banner looks like this:
![2018-10-09t16 24 11 02 00](https://user-images.githubusercontent.com/8876997/46675915-c222b480-cbdf-11e8-86fa-cc16035c9bac.png)
