### PR TITLE
Add emergency phone number field to admin member creation view

### DIFF
--- a/app/views/admin/members/new.html.haml
+++ b/app/views/admin/members/new.html.haml
@@ -66,6 +66,10 @@
                 = f.telephone_field :phone_number, :value => @member.phone_number, :class => 'form-control'
 
               .form-group
+                = f.label(:emergency_phone_number)
+                = f.telephone_field :emergency_phone_number, :value => @member.emergency_phone_number, :class => 'form-control'
+
+              .form-group
                 = f.label(:email)
                 = f.email_field :email, :value => @member.email, :class => 'form-control'
                 .help-block Dit kan niet een uu email zijn!


### PR DESCRIPTION
When adding the emergency phone number I forgot to add it to the admin member creation view making it impossible for admins to add members who aren't 18.