### PR TITLE
Use Docker for the development database, update install guide

### DIFF
--- a/.dev-database-conf/custom-overrides.cnf
+++ b/.dev-database-conf/custom-overrides.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+innodb_file_format=Barracuda
+innodb_large_prefix=1
+innodb_file_per_table=1
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci

--- a/.rbenv-vars-sample
+++ b/.rbenv-vars-sample
@@ -1,16 +1,28 @@
 # Database credentials: choose either SOCKET or  (HOST,USER,PASSWORD)
 DATABASE_SOCKET=
 
-DATABASE_HOST=
-DATABASE_USER=
-DATABASE_PASSWORD=
+# If running in development, use this:
+DATABASE_HOST=127.0.0.1
+DATABASE_USER=root
+DATABASE_PASSWORD=koala123
+DATABASE_PORT=25838
+
+# Hostname of where Koala is running, like https://koala.svsticky.nl or http://koala.rails.local:3000
+KOALA_DOMAIN=
 
 # Secrets
+# Each of these values needs to be set to a random string.
+# You could get them from here:
+# https://www.random.org/strings/?num=3&len=20&digits=on&upperalpha=on&loweralpha=on&unique=off&format=html&rnd=new
 SECRET_KEY_BASE=
 DEVISE_SECRET=
+CHECKOUT_TOKEN=
+
+# All the below values can be left empty/default in development.
 OIDC_SIGNING_KEY=
 
 # OAuth secrets for OAuth proxy
+# Not needed in development.
 OAUTH_PROXY_UID=
 OAUTH_PROXY_SECRET=
 OAUTH_PROXY_REDIRECTS=https://photos.svsticky.nl/oauth2/callback;https://files.svsticky.nl/oauth2/callback
@@ -18,10 +30,6 @@ OAUTH_PROXY_REDIRECTS=https://photos.svsticky.nl/oauth2/callback;https://files.s
 # API tokens
 MAILGUN_DOMAIN=
 MAILGUN_TOKEN=
-CHECKOUT_TOKEN=
-
-# Hostname of where Koala is running, like https://koala.svsticky.nl or http://koala.rails.local:3000
-KOALA_DOMAIN=
 
 # MOLLIE credentials
 MOLLIE_DOMAIN=https://api.mollie.nl
@@ -31,4 +39,4 @@ MOLLIE_TOKEN=
 # Number of threads to run
 RAILS_MAX_THREADS=4
 
-SENTRY_DSN=http://public:secret@example.com/project-id
+SENTRY_DSN=

--- a/.rbenv-vars-sample
+++ b/.rbenv-vars-sample
@@ -1,25 +1,48 @@
-# Database credentials: choose either SOCKET or  (HOST,USER,PASSWORD)
-DATABASE_SOCKET=
-
-# If running in development, use this:
+### Database setup ###
+# If you're running in development and using the Docker setup for the database,
+# use these values:
 DATABASE_HOST=127.0.0.1
 DATABASE_USER=root
 DATABASE_PASSWORD=koala123
 DATABASE_PORT=25838
 
-# Hostname of where Koala is running, like https://koala.svsticky.nl or http://koala.rails.local:3000
-KOALA_DOMAIN=
+# Otherwise, if you're using a local Mariadb setup, uncomment and fill in this:
 
-# Secrets
-# Each of these values needs to be set to a random string.
-# You could get them from here:
-# https://www.random.org/strings/?num=3&len=20&digits=on&upperalpha=on&loweralpha=on&unique=off&format=html&rnd=new
+# Database socket, usually /run/mysqld/mysqld.sock
+#DATABASE_SOCKET=/run/mysqld/mysqld.sock
+
+# Host where your database is running. If you're running locally and using a
+# Unix socket, set this to "localhost", if you're using a TCP socket, set this
+# to an IP address.
+#DATABASE_HOST=localhost
+
+# Port to use for the connection. The default is 3306, and this value is not
+# used if you're using a Unix socket.
+#DATABASE_PORT=3306
+
+# Credentials to use. This user will need to have all privileges on the
+# `koala-development` and `koala-test` databases.
+#DATABASE_USER=
+#DATABASE_PASSWORD=
+
+### Secrets ###
+# Each of these values needs to be set to a random string. It doesn't matter
+# what the actual value is, generate random strings with the command `rake secret`.
 SECRET_KEY_BASE=
 DEVISE_SECRET=
 CHECKOUT_TOKEN=
 
 # All the below values can be left empty/default in development.
-OIDC_SIGNING_KEY=
+RAILS_ENV=development
+
+# Hostname of where Koala is running, like https://koala.svsticky.nl or http://koala.rails.local:3000
+KOALA_DOMAIN=http://koala.rails.local:3000
+
+# Number of threads to run
+RAILS_MAX_THREADS=4
+
+# Signing key for OpenID tokens
+OIDC_SIGNING_KEY=.circleci/test-signing-key.pem
 
 # OAuth secrets for OAuth proxy
 # Not needed in development.
@@ -27,16 +50,15 @@ OAUTH_PROXY_UID=
 OAUTH_PROXY_SECRET=
 OAUTH_PROXY_REDIRECTS=https://photos.svsticky.nl/oauth2/callback;https://files.svsticky.nl/oauth2/callback
 
-# API tokens
+# API tokens for sending email. Don't fill in in development, or you'll send a
+# lot of emails to @example.com.
 MAILGUN_DOMAIN=
 MAILGUN_TOKEN=
 
-# MOLLIE credentials
+# MOLLIE credentials for the iDEAL integration.
 MOLLIE_DOMAIN=https://api.mollie.nl
 MOLLIE_VERSION=v1
 MOLLIE_TOKEN=
 
-# Number of threads to run
-RAILS_MAX_THREADS=4
-
+# Secret for error reporting.
 SENTRY_DSN=

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -104,7 +104,15 @@ To easily start the database, you can run MariaDB in a container via Docker.
 Follow these steps to install Docker and start the database:
 
 ```console
+# Install Docker and Docker Compose
 $ sudo apt install docker.io docker-compose
+
+# Add yourself to the `docker` system group (needed only once)
+# NOTE: You need to log out and log in again to apply this!
+$ sudo usermod -aG docker $USER
+
+# Install and start the database
+# If you don't want to log out and log in again, use `sudo` here.
 $ docker-compose up -d
 ```
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,22 +6,24 @@ development:
   username: <%= ENV['DATABASE_USER'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
   socket: <%= ENV['DATABASE_SOCKET'] %>
+  port: <%= ENV['DATABASE_PORT'] %>
   host: <%= ENV['DATABASE_HOST'] %>
   pool: 5
   timeout: 5000
-  encoding: utf8
+  encoding: utf8mb4
 
 # test
-# Version used by circleci
+# Version used by circleci and the local tests
 test:
   adapter: mysql2
   database: koala-test
   host:  127.0.0.1
   username: <%= ENV['DATABASE_USER'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
+  port: <%= ENV['DATABASE_PORT'] %>
   pool: 5
   timeout: 5000
-  encoding: utf8
+  encoding: utf8mb4
 
 # Production
 # Version for public use running on svsticky.nl
@@ -34,7 +36,7 @@ production:
   host: localhost
   pool: 5
   timeout: 5000
-  encoding: utf8
+  encoding: utf8mb4
 
 # Staging
 # Version for QA running on dev.svsticky.nl
@@ -47,4 +49,4 @@ staging:
   host: localhost
   pool: 5
   timeout: 5000
-  encoding: utf8
+  encoding: utf8mb4

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -190,7 +190,7 @@ nl:
 
       models:
         activity:
-          activity_ended: "Deze activiteit is (niet) meer beschikbaar. Ga terug."
+          activity_ended: "Deze activiteit is niet (meer) beschikbaar. Ga terug."
           already_enrolled: "Je bent al ingeschreven voor deze activiteit."
           attributes:
             end_date:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+---
+# This is a Docker Compose file.
+# See the docs at https://docs.docker.com/compose/
+version: "3"
+services:
+  koala-development-database:
+    # We pin the database version to the exact version used on the live server.
+    # Bug the IT Crowd if you think this version changed.
+    image: mariadb:10.1.41-bionic
+
+    # We set this service up to run on a nonstandard port, so that we don't
+    # interfere with a possibly already running Mariadb instance.
+    # Port 25838 = the digits above "STICK" on a keyboard.
+    # You are then able to connect using this command:
+    # mysql -P 25838 -u root -p
+    ports:
+      - "25838:3306"
+
+    # Configuration for how to connect, this should match Koala's config in
+    # ./config/database.yml!  See here for possible values:
+    # https://hub.docker.com/_/mariadb?tab=description#environment-variables
+    environment:
+      # We run Koala as the root user so that it can do anything it wants with
+      # the development database, and you don't need to manually create the
+      # development, test databases and grant permissions on it.
+      MYSQL_ROOT_PASSWORD: "koala123"
+
+    # The .dev-database-conf directory contains a configuration file which
+    # enables extra features in MariaDB that we require. This directive
+    # includes this directory in the container as /etc/mysql/conf.d:
+    volumes:
+      - ".dev-database-conf:/etc/mysql/conf.d"


### PR DESCRIPTION
This PR adds setup and instructions to run the development database in a Docker container, and expands the install guide.

The Docker setup was added in response to concerns that the database setup was too hard, and to prevent problems from occurring due to a mismatch between the MariaDB version used in development and the version on the server.

The new Docker setup is __not required__, and is intended to not interfere with a possibly existing MariaDB on the host by using a nonstandard port.

CC @Riscky 