### PR TITLE
Fix crash when searching for Members

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -7,9 +7,9 @@ class Admin::MembersController < ApplicationController
     @limit = params[:limit] ? params[:limit].to_i : 50
 
     if params[:search]
-      @members = Member.search(params[:search].clone)
-                       .paginate(page: param[:page], per_page: params[:limit] ||= 50)
-
+      params[:page] ||= 1
+      params[:limit] ||= 50
+      @members = Member.search(params[:search].clone, params[:page], params[:limit])
       @search = params[:search]
 
       redirect_to @members.first if @members.size == 1 && params[:page] ||= 1

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -6,13 +6,19 @@ class Admin::MembersController < ApplicationController
   def index
     @limit = params[:limit] ? params[:limit].to_i : 50
 
-    if params[:search]
-      params[:page] ||= 1
-      params[:limit] ||= 50
-      @members = Member.search(params[:search].clone, params[:page], params[:limit])
+    if params[:search].present?
       @search = params[:search]
 
-      redirect_to @members.first if @members.size == 1 && params[:page] ||= 1
+      params[:page] ||= 1
+      @page = params[:page].to_i
+
+      params[:limit] ||= 50
+      @limit = params[:limit].to_i
+      offset = (@page - 1) * @limit
+
+      @members = Member.search(@search.clone, offset, @limit)
+
+      redirect_to @members.first if @members.size == 1 && @page == 1
 
     else
       @members =

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -177,7 +177,7 @@ class Member < ApplicationRecord
   end
 
   # Functions starting with self are functions on the model not an instance. For example we can now search for members by calling Member.search with a query
-  def self.search(query)
+  def self.search(query, page = 1, limit = 50)
     student_id = query.match(/^\F?\d{6,7}$/i)
     return where("student_id like ?", "%#{ student_id }%") unless student_id.nil?
 
@@ -188,7 +188,7 @@ class Member < ApplicationRecord
     return where(:id => (Education.select(:member_id).where('status = 0').map(&:member_id) + Tag.select(:member_id).where(:name => Tag.active_by_tag).map(&:member_id))) if query.blank?
 
     records = filter(query)
-    return records.find_by_fuzzy_query(query) unless query.blank?
+    return records.find_by_fuzzy_query(query, limit: limit, page: page) unless query.blank?
 
     return records
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -177,7 +177,7 @@ class Member < ApplicationRecord
   end
 
   # Functions starting with self are functions on the model not an instance. For example we can now search for members by calling Member.search with a query
-  def self.search(query, page = 1, limit = 50)
+  def self.search(query, offset = 0, limit = 50)
     student_id = query.match(/^\F?\d{6,7}$/i)
     return where("student_id like ?", "%#{ student_id }%") unless student_id.nil?
 
@@ -188,7 +188,7 @@ class Member < ApplicationRecord
     return where(:id => (Education.select(:member_id).where('status = 0').map(&:member_id) + Tag.select(:member_id).where(:name => Tag.active_by_tag).map(&:member_id))) if query.blank?
 
     records = filter(query)
-    return records.find_by_fuzzy_query(query, limit: limit, page: page) unless query.blank?
+    return records.find_by_fuzzy_query(query, limit: limit, offset: offset) unless query.blank?
 
     return records
   end

--- a/app/views/admin/members/index.html.haml
+++ b/app/views/admin/members/index.html.haml
@@ -57,7 +57,6 @@
               %td= link_to "#{member.student_id}", member
               %td= link_to "#{member.educations.map{ |s| s.study.code }.join(', ')}", member
 
-      - if @search == nil
         %footer.table-footer
           .row
             .col-lg-5.page-num-info.d-none.d-sm-block{ :data => { :limit => @limit, :pagination => 4, :search => @search, :all => @all } }
@@ -66,5 +65,20 @@
                 = select_tag 'limit', options_for_select([20,50,100], @limit)
                 leden per pagina
 
-            .col-lg-6
-              = will_paginate @members, renderer: WillPaginate::ActionView::BootstrapLinkRenderer
+            -# will_paginate doesn't work for search results, so we use a simpler footer then
+            - if @search.present?
+              .col-lg-3
+                -# Only show button if there are pages to go back to
+                - if @page > 1
+                  = link_to( { search: @search, limit: @limit.to_i, page: @page - 1 }, class: 'btn btn-light') do
+                    ="←"
+
+              .col-lg-3
+                -# Only show button if there are as many results as the limit
+                - if @members.count >= @limit
+                  = link_to( { search: @search, limit: @limit, page: @page + 1 }, class: 'btn btn-light') do
+                    ="→"
+
+            - else
+              .col-lg-6
+                = will_paginate @members, renderer: WillPaginate::ActionView::BootstrapLinkRenderer

--- a/app/views/admin/members/index.html.haml
+++ b/app/views/admin/members/index.html.haml
@@ -69,13 +69,13 @@
 
             -# will_paginate doesn't work for search results, so we use a simpler footer then
             - if @search.present?
-              .col-lg-3
+              .col-lg-3.text-center
                 -# Only show button if there are pages to go back to
                 - if @page > 1
                   = link_to( { search: @search, limit: @limit.to_i, page: @page - 1 }, class: 'btn btn-light') do
                     ="←"
 
-              .col-lg-3
+              .col-lg-3.text-center
                 -# Only show button if there are as many results as the limit
                 - if @members.count >= @limit
                   = link_to( { search: @search, limit: @limit, page: @page + 1 }, class: 'btn btn-light') do

--- a/app/views/admin/members/index.html.haml
+++ b/app/views/admin/members/index.html.haml
@@ -57,13 +57,14 @@
               %td= link_to "#{member.student_id}", member
               %td= link_to "#{member.educations.map{ |s| s.study.code }.join(', ')}", member
 
-      %footer.table-footer
-        .row
-          .col-lg-5.page-num-info.d-none.d-sm-block{ :data => { :limit => @limit, :pagination => 4, :search => @search, :all => @all } }
-            %span
-              Toon
-              = select_tag 'limit', options_for_select([20,50,100], @limit)
-              leden per pagina
+      - if @search == nil
+        %footer.table-footer
+          .row
+            .col-lg-5.page-num-info.d-none.d-sm-block{ :data => { :limit => @limit, :pagination => 4, :search => @search, :all => @all } }
+              %span
+                Toon
+                = select_tag 'limit', options_for_select([20,50,100], @limit)
+                leden per pagina
 
-          .col-lg-6
-            = will_paginate @members, renderer: WillPaginate::ActionView::BootstrapLinkRenderer
+            .col-lg-6
+              = will_paginate @members, renderer: WillPaginate::ActionView::BootstrapLinkRenderer

--- a/app/views/admin/members/index.html.haml
+++ b/app/views/admin/members/index.html.haml
@@ -51,8 +51,10 @@
               %td= link_to "#{member.first_name}", member
               %td= link_to "#{member.infix}", member
               %td= link_to "#{member.last_name}", member
-              %td.d-none.d-sm-table-cell= link_to "#{member.phone_number}", member
-              %td.d-block.d-sm-none= link_to "#{member.phone_number}", "tel:#{member.phone_number}", :style => 'color: darkblue;'
+              %td
+                = link_to "tel:#{member.phone_number}" do
+                  %i.fa.fa-phone
+                  = member.phone_number
               %td= link_to "#{member.email}", member
               %td= link_to "#{member.student_id}", member
               %td= link_to "#{member.educations.map{ |s| s.study.code }.join(', ')}", member


### PR DESCRIPTION
Fixes #489.

This PR will add a more basic pagination parameter for the search results, containing only 'next' and 'previous' buttons.

Also fixes an issue that caused the pagination numbers to render inside the column for the limit dropdown.