### PR TITLE
Require notes if public or mandatory is checked

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -25,6 +25,8 @@ class Activity < ApplicationRecord
     errors.add(:poster, I18n.t('activerecord.errors.unsupported_content_type', :type => poster.content_type.to_s, :allowed => 'application/pdf image/jpeg image/png')) if poster.attached? && !poster.content_type.in?(['application/pdf', 'image/jpeg', 'image/png'])
   end
 
+  validates :notes, presence: true, if: proc { |a| a.notes_public? || a.notes_mandatory? }
+
   # Disabled validations
   # validates :end_date
   # validates :description


### PR DESCRIPTION
Fixes #488 

Extra notes are now required if either public or mandatory is checked.
The seeds seem to already take this into account and won't have nonexistent mandatory notes.