### PR TITLE
Add change password option for members

### DIFF
--- a/app/controllers/users/password_change_controller.rb
+++ b/app/controllers/users/password_change_controller.rb
@@ -15,7 +15,8 @@ class Users::PasswordChangeController < ApplicationController
     # Require current_password when changing the password and check if a
     # new password was entered manually because Devise doesn't think it's
     # necessary
-    if @user.update_with_password(user_params) && !params[:password].nil?
+
+    if @user.update_with_password(user_params) && !params[:user][:password].empty?
       bypass_sign_in @user, scope: :user
       redirect_to root_path
     else

--- a/app/controllers/users/password_change_controller.rb
+++ b/app/controllers/users/password_change_controller.rb
@@ -12,7 +12,10 @@ class Users::PasswordChangeController < ApplicationController
 
   def update
     @user = current_user
-    if @user.update_with_password(user_params) # current_password required to change password
+    # Require current_password when changing the password and check if a
+    # new password was entered manually because Devise doesn't think it's
+    # necessary
+    if @user.update_with_password(user_params) && !params[:password].nil?
       bypass_sign_in @user, scope: :user
       redirect_to root_path
     else

--- a/app/controllers/users/password_change_controller.rb
+++ b/app/controllers/users/password_change_controller.rb
@@ -1,0 +1,28 @@
+# Controller used to change a user's password
+class Users::PasswordChangeController < ApplicationController
+  skip_before_action :authenticate_admin!
+
+  layout 'members'
+
+  def edit
+    @user = current_user
+
+    render 'user/password/edit'
+  end
+
+  def update
+    @user = current_user
+    if @user.update_with_password(user_params) # current_password required to change password
+      bypass_sign_in @user, scope: :user
+      redirect_to root_path
+    else
+      render 'user/password/edit'
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:current_password,
+                                 :password,
+                                 :password_confirmation)
+  end
+end

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -87,11 +87,11 @@
       .card
         .card-header
           %i.fa.fa-fw.fa-key
-          = "Wachtwoord veranderen" #TODO: needs translation
+          = I18n.t 'members.home.edit.password_options.header'
         .card-body
           = link_to password_change_path, { :class => 'button btn btn-warning' } do
             %i.fa.fa-key
-            Verander wachtwoord
+            = I18n.t 'members.home.edit.password_options.change_password'
 
 
     .col-xl-6
@@ -168,7 +168,8 @@
     .col-xl-12
       .card
         .card-body
-          %button.btn.btn-success{type: 'submit'} Opslaan
+          %button.btn.btn-success{type: 'submit'}
+            = I18n.t("editing.save")
           = link_to I18n.t("editing.cancel"), users_root_path, { :class => 'button btn btn-secondary' }
           = link_to download_path, { :class => 'button btn btn-secondary pull-right' } do
             %i.fa.fa-download

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -84,6 +84,16 @@
             %span.footnote 2
             .help-block Als je minderjarig bent is het verplicht om een telefoonnummer in te vullen voor noodgevallen.
 
+      .card
+        .card-header
+          %i.fa.fa-fw.fa-key
+          = "Wachtwoord veranderen" #TODO: needs translation
+        .card-body
+          = link_to edit_password_path, { :class => 'button btn btn-warning' } do
+            %i.fa.fa-key
+            Verander wachtwoord
+
+
     .col-xl-6
       .card
         .card-header

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -89,7 +89,7 @@
           %i.fa.fa-fw.fa-key
           = "Wachtwoord veranderen" #TODO: needs translation
         .card-body
-          = link_to edit_password_path, { :class => 'button btn btn-warning' } do
+          = link_to password_change_path, { :class => 'button btn btn-warning' } do
             %i.fa.fa-key
             Verander wachtwoord
 

--- a/app/views/user/password/edit.html.haml
+++ b/app/views/user/password/edit.html.haml
@@ -36,5 +36,6 @@
     .offset-xl-3.col-xl-6
       .card
         .card-body
-          %button.btn.btn-success{type: 'submit'} Submit
+          %button.btn.btn-success{type: 'submit'}
+            = I18n.t("editing.save")
           = link_to I18n.t("editing.cancel"), "#", { :class => 'button btn btn-secondary' }

--- a/app/views/user/password/edit.html.haml
+++ b/app/views/user/password/edit.html.haml
@@ -14,7 +14,7 @@
       .card
         .card-header
           %i.fa.fa-fw.fa-key
-          Wachtwoord veranderen
+          = I18n.t("members.home.edit.password_options.change_password")
         .card-body
           .form-group
             .row

--- a/app/views/user/password/edit.html.haml
+++ b/app/views/user/password/edit.html.haml
@@ -1,0 +1,40 @@
+= form_for :user, method: :patch, :class => 'form-validation' do |f|
+
+  - if @user.errors.any? || flash[:error]
+    .alert.alert-danger.offset-xl-3.col-xl-6
+      %span= I18n.t('activerecord.errors.incomplete')
+      %ul
+        - @user.errors.full_messages.each do |msg|
+          %li= msg
+        - if flash[:error].present?
+          %li= flash[:error]
+
+  .row
+    .offset-xl-3.col-xl-6
+      .card
+        .card-header
+          %i.fa.fa-fw.fa-key
+          Wachtwoord veranderen
+        .card-body
+          .form-group
+            .row
+              .col-lg-12
+                = f.label(:current_password)
+                = f.password_field :current_password, :class => 'form-control'
+
+            .row
+              .col-lg-12
+                = f.label(:password)
+                = f.password_field :password, :class => 'form-control'
+
+            .row
+              .col-lg-12
+                = f.label(:password_confirmation)
+                = f.password_field :password_confirmation, :class => 'form-control'
+
+  .row
+    .offset-xl-3.col-xl-6
+      .card
+        .card-body
+          %button.btn.btn-success{type: 'submit'} Submit
+          = link_to I18n.t("editing.cancel"), users_edit_path, { :class => 'button btn btn-secondary' }

--- a/app/views/user/password/edit.html.haml
+++ b/app/views/user/password/edit.html.haml
@@ -38,4 +38,4 @@
         .card-body
           %button.btn.btn-success{type: 'submit'}
             = I18n.t("editing.save")
-          = link_to I18n.t("editing.cancel"), "#", { :class => 'button btn btn-secondary' }
+          = link_to I18n.t("editing.cancel"), users_edit_path, { :class => 'button btn btn-secondary' }

--- a/app/views/user/password/edit.html.haml
+++ b/app/views/user/password/edit.html.haml
@@ -37,4 +37,4 @@
       .card
         .card-body
           %button.btn.btn-success{type: 'submit'} Submit
-          = link_to I18n.t("editing.cancel"), users_edit_path, { :class => 'button btn btn-secondary' }
+          = link_to I18n.t("editing.cancel"), "#", { :class => 'button btn btn-secondary' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,6 +136,7 @@ en:
           suspended: Suspended
       user:
         email: e-mailaddress
+        current_password: Current password
         password: password
         password_confirmation: "Repeat password"
     errors:
@@ -488,6 +489,9 @@ en:
           header: "Privacy"
           view: "View the"
           privacy_statement: "privacy statement"
+        password_options:
+          header: "Password options"
+          change_password: "Change password"
       index:
         edit_profile: "Edit profile"
         outstanding_payments: "Outstanding payments"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -170,6 +170,7 @@ nl:
           true: "Betaald"
       user:
         email: E-mailadres
+        current_password: Huidig wachtwoord
         password: Wachtwoord
         password_confirmation: "Herhaal wachtwoord"
     errors:
@@ -502,6 +503,9 @@ nl:
           header: "Privacy"
           view: "Bekijk de"
           privacy_statement: "privacy statement"
+        password_options:
+          header: "Wachtwoord opties"
+          change_password: "Verander wachtwoord"
       index:
         edit_profile: "Gegevens bewerken"
         outstanding_payments: "Openstaande betalingen"
@@ -511,6 +515,7 @@ nl:
   navigation:
     back: Terug
     home: Home
+    submit: Opslaan
   time:
     formats:
       default: "%d-%m-%Y %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,10 @@ Rails.application.routes.draw do
     get     'activate',     to: 'users/registrations#edit', as: :new_member_confirmation
     post    'activate',     to: 'users/registrations#update', as: :new_member_confirm
 
+    # update password from member options
+    get     'password',     to: 'users/password_change#edit', as: :edit_password
+    patch   'password',     to: 'users/password_change#update'
+
     scope module: 'public' do
       get   'status(/:token)', to: 'status#edit'
       post  'status',          to: 'status#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,8 +55,8 @@ Rails.application.routes.draw do
     post    'activate',     to: 'users/registrations#update', as: :new_member_confirm
 
     # update password from member options
-    get     'password',     to: 'users/password_change#edit', as: :edit_password
-    patch   'password',     to: 'users/password_change#update'
+    get     'passwordchange',     to: 'users/password_change#edit', as: :password_change
+    patch   'passwordchange',     to: 'users/password_change#update'
 
     scope module: 'public' do
       get   'status(/:token)', to: 'status#edit'


### PR DESCRIPTION
Fixes #393 

Members can now change their password through the member edit page instead of having to click "forgot password".