### PR TITLE
Bump rabl from 0.14.1 to 0.14.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       ast (~> 2.4.0)
     puma (4.1.0)
       nio4r (~> 2.0)
-    rabl (0.14.1)
+    rabl (0.14.2)
       activesupport (>= 2.3.14)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -234,7 +234,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
@@ -258,7 +258,7 @@ GEM
     will_paginate (3.1.7)
     will_paginate-bootstrap4 (0.2.2)
       will_paginate (~> 3.0, >= 3.0.0)
-    zeitwerk (2.1.10)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
[Changelog](https://github.com/nesquena/rabl/blob/master/CHANGELOG.md#0142-september-10th-2019)
rabl 0.14.1 is not compatible with rails 6 so everything using rabl templates (mainly the API) is broken.
After updating to 0.14.2 the templates work as expected.