### PR TITLE
Fix future outstanding payments

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -9,7 +9,7 @@ class Admin::HomeController < ApplicationController
     @transactions = CheckoutTransaction.count(:all)
     @recent = CheckoutTransaction.where("created_at >= ?", Time.zone.now.beginning_of_day).order(created_at: :desc).take(12)
 
-    @unpayed = Participant.where(:reservist => false, :paid => false).sum(:price) + Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity).where('activities.price IS NOT NULL').sum('activities.price')
+    @unpayed = Participant.where(:reservist => false, :paid => false).joins(:activity).where('activities.start_date < NOW()').sum(:price) + Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity).where('activities.start_date < NOW()').sum('activities.price')
 
     @defaulters = Participant.where(:reservist => false, :paid => false).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum(:price).merge( \
       Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum('activities.price ')

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -9,7 +9,7 @@ class Admin::HomeController < ApplicationController
     @transactions = CheckoutTransaction.count(:all)
     @recent = CheckoutTransaction.where("created_at >= ?", Time.zone.now.beginning_of_day).order(created_at: :desc).take(12)
 
-    @unpayed = Participant.where(:reservist => false, :paid => false).joins(:activity).where('activities.start_date < NOW()').sum(:price) + Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity).where('activities.start_date < NOW()').sum('activities.price')
+    @unpayed = Participant.where(:reservist => false, :paid => false).joins(:activity).where('activities.start_date < NOW()').sum(:price) + Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity).where('activities.start_date < NOW() AND activities.price IS NOT NULL').sum('activities.price')
 
     @defaulters = Participant.where(:reservist => false, :paid => false).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum(:price).merge( \
       Participant.where(:reservist => false, :paid => false, :price => nil).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum('activities.price ')


### PR DESCRIPTION
Fixes #507 

Added a additional query to check if activities are before the current time. 