### PR TITLE
WIP: fixed zoom problems

### DIFF
--- a/app/assets/stylesheets/admin/activities.css
+++ b/app/assets/stylesheets/admin/activities.css
@@ -93,12 +93,10 @@
     display: none;
   }
 
-  form span.poster {
-    height: 255px;
-    width: 180px;
-    margin-top: 29px;
+  form .poster {
+    max-height: 255px;
+    max-width: 180px;
     border: solid 1px #cbd5dd;
-    overflow: hidden;
   }
 }
 

--- a/app/views/admin/activities/partials/_edit.html.haml
+++ b/app/views/admin/activities/partials/_edit.html.haml
@@ -26,12 +26,13 @@
 
       .form-group
         .row
-          .col-lg-3
-            %span.poster.d-none.d-lg-block
+          .col-md-4
+            = label(:activity, :poster, class: 'd-none d-md-block')
+            .div.poster.d-none.d-md-block
               - if @activity.poster.attached?
-                = image_tag @activity.poster.representation(resize: '180x255!')
+                = image_tag @activity.poster.representation(resize: '180x255!'), :class => 'img-fluid'
 
-          .col-lg-9
+          .col-md-8
             = label(:activity, :description)
             = f.text_area :description, :value => @activity.description, :class => 'form-control', :rows => 8
 

--- a/app/views/admin/home/index.html.haml
+++ b/app/views/admin/home/index.html.haml
@@ -6,7 +6,7 @@
   .page
     .row
 
-      .col-12.col-md-6.col-xl-3
+      .col-12.col-md-6
         .card
           = link_to :members do
             .row.no-gutters
@@ -17,7 +17,7 @@
                   = @members
                 %p.text-muted Leden
 
-      .col-12.col-md-6.col-xl-3
+      .col-12.col-md-6
         .card
           = link_to :activities do
             .row.no-gutters
@@ -28,7 +28,7 @@
                   = @activities
                 %p.text-muted Activiteiten
 
-      .col-12.col-md-6.col-xl-3
+      .col-12.col-md-6
         .card
           = link_to :checkout do
             .row.no-gutters
@@ -39,7 +39,7 @@
                   = @transactions
                 %p.text-muted Checkout transacties
 
-      .col-12.col-md-6.col-xl-3
+      .col-12.col-md-6
         .card
           = link_to :payments do
             .row.no-gutters


### PR DESCRIPTION
Removed 4 collumn layout for admin home page shortcuts
This was giving problemns on screensizes between 1200px and 1600px
Blame Bootstrap for not adding an xxl screen size