### PR TITLE
Update URL of privacy statement

### DIFF
--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -151,7 +151,7 @@
           = I18n.t 'members.home.edit.privacy_panel.header'
         .card-body
           = I18n.t 'members.home.edit.privacy_panel.view'
-          = link_to 'https://svsticky.nl/wp-content/uploads/privacystatement.pdf' do
+          = link_to 'https://assets.ctfassets.net/7cqe14fu3dhm/3hfUx8SkJ8zKH9lGZOaEO2/722641bcf897d90afa1e17e100e45627/Privacystatement.pdf' do
             = I18n.t 'members.home.edit.privacy_panel.privacy_statement'
 
   - if @applications.any?

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -151,7 +151,7 @@
           = I18n.t 'members.home.edit.privacy_panel.header'
         .card-body
           = I18n.t 'members.home.edit.privacy_panel.view'
-          = link_to 'https://assets.ctfassets.net/7cqe14fu3dhm/3hfUx8SkJ8zKH9lGZOaEO2/722641bcf897d90afa1e17e100e45627/Privacystatement.pdf' do
+          = link_to 'https://public.svsticky.nl/privacystatement.pdf' do
             = I18n.t 'members.home.edit.privacy_panel.privacy_statement'
 
   - if @applications.any?


### PR DESCRIPTION
I noticed the privacy statement on the member page still displayed the old one hosted on old.svsticky.nl. I updated it to the most recent Dutch one. There's a more recent statement, but that one's in English. If we would prefer to use that one, please let me know.