### PR TITLE
Fix db:setup in local koala

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,18 @@ services:
     # includes this directory in the container as /etc/mysql/conf.d:
     volumes:
       - ".dev-database-conf:/etc/mysql/conf.d"
+
+  redis:
+    image: 'bitnami/redis:5.0'
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+    ports:
+      - '6379:6379'
+    volumes:
+      - 'redis_data:/bitnami/redis/data'
+
+volumes:
+  redis_data:
+    driver: local


### PR DESCRIPTION
Adds Redis to the docker-compose. db:setup needs this now, which caused the old version to fail as redis was not present.