### PR TITLE
Fix member edit form breaking on refresh

### DIFF
--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for(:page, "edit")
 - content_for(:title, @member.name)
 
-= form_for :member, method: :patch, authenticity_token: true, :class => 'form-validation' do |f|
+= form_for :member, method: :post, :class => 'form-validation' do |f|
 
   - if @member.errors.any? || flash[:error]
     .alert.alert-danger
@@ -43,7 +43,7 @@
               .col-md-8
                 = f.label(:email) + "¹"
                 = f.email_field :email, :value => @member.email, :class => 'form-control'
-              
+
               .col-md-4
                 = f.label(:language)
                 = f.select :language, options_for_select([["Nederlands", :nl], ["English", :en]], selected: @user.language), {:class => 'form-control'}
@@ -149,7 +149,7 @@
             .callout.callout-info
               = I18n.t('members.home.edit.edit_study_info')
               %br
-              %br 
+              %br
               #{ I18n.t('members.home.edit.mutate_study') } #{link_to I18n.t('members.home.edit.board'), 'mailto:bestuur@svsticky.nl'}.
 
       .card

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
         root to: 'home#index', as: :users_root
 
         get   'edit',                           to: 'home#edit', as: :users_edit
-        patch 'edit',                           to: 'home#update'
+        post  'edit',                           to: 'home#update'
         delete 'authorized_applications/:id',   to: 'home#revoke', as: :authorized_applications
 
         get 'download', to: 'home#download'


### PR DESCRIPTION
Closes #587 
For some reason rails keeps overwriting the _method field with a token on refresh even with authenticity_token: false.
By using post the _method field is no longer required and can't be overwritten.