### PR TITLE
Removed the 'Elfproef' from the studentID validity check.

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -390,6 +390,5 @@ class Member < ApplicationRecord
     # do not do the elfproef on a foreign student
     return if student_id =~ /\F\d{6}/
     return if student_id.blank?
-
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -391,15 +391,5 @@ class Member < ApplicationRecord
     return if student_id =~ /\F\d{6}/
     return if student_id.blank?
 
-    numbers = student_id.split("").map(&:to_i).reverse
-
-    sum = 0
-    numbers.each_with_index do |digit, i|
-      i += 1
-      sum += digit * i
-    end
-
-    # Errors are added direclty to the model, so it easy to show in the views. We are using I18n for translating purposes, a lot is still hardcoded dutch, but not the intro website and studies
-    errors.add :student_id, I18n.t('activerecord.errors.models.member.attributes.student_id.elfproef') if sum % 11 != 0
   end
 end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -55,7 +55,7 @@ class MemberTest < ActiveSupport::TestCase
     m.student_id = 'F133742'
     assert m.save, 'F-number marked invalid'
 
-    m.student_id = '0000001'
+    m.student_id = '000000'
     assert_not m.save, 'Invalid student id marked valid'
 
     m.student_id = ''


### PR DESCRIPTION
Because some studentID's can't be validated with the elfproef I removed this check from Koala.