### PR TITLE
Fix member update if member is not in mailchimp

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -79,7 +79,7 @@ class Admin::MembersController < ApplicationController
     if @member.update member_post_params.except 'mailchimp_interests'
 
       MailchimpJob.perform_later email, @member, params[:member][:mailchimp_interests].reject(&:blank?) unless
-        ENV['MAILCHIMP_DATACENTER'].blank?
+      ENV['MAILCHIMP_DATACENTER'].blank? || params[:member][:mailchimp_interests].nil?
 
       impressionist @member
       redirect_to @member

--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -69,8 +69,8 @@ class Members::HomeController < ApplicationController
     @member = Member.find(current_user.credentials_id)
 
     if @member.update member_post_params.except 'mailchimp_interests'
-      MailchimpJob.perform_later @member.email, @member, params[:member][:mailchimp_interests].select { |_, val| val == '1' }.keys unless
-        ENV['MAILCHIMP_DATACENTER'].blank?
+      MailchimpJob.perform_later @member.email, @member, params[:member][:mailchimp_interests].reject(&:blank?) unless
+      ENV['MAILCHIMP_DATACENTER'].blank? || params[:member][:mailchimp_interests].nil?
 
       impressionist(@member, I18n.t('activerecord.attributes.impression.member.update'))
 


### PR DESCRIPTION
Closes #746 

When someone signs up they are automatically added to mailchimp.
Some old users don't exist in mailchimp, these can be manually added if necessary.
Once they have been added, their interests will become visible on the show and edit views and they will be synchronized with mailchimp.
This PR stops the synchronization attempts for members who don't exist in mailchimp.