### PR TITLE
Add message for members not in mailchimp, add missing translation

### DIFF
--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -97,10 +97,12 @@
                     %span.label.label-info
                       = I18n.t('activerecord.attributes.education.status.active')
 
-            - unless ENV['MAILCHIMP_DATACENTER'].blank? || @member.mailchimp_interests.nil?
-              %dl.dl-horizontal
-                %dt Mailchimp lijsten
+            %dl.dl-horizontal
+              %dt= I18n.t('admin.members.mailinglists')
+              - unless ENV['MAILCHIMP_DATACENTER'].blank? || @member.mailchimp_interests.nil?
                 %dd= @member.mailchimp_interests&.select{ |_,v| v == true}&.map{ |k, _| Rails.configuration.mailchimp_interests.key(k) }&.join(', ')
+              - else
+                %dd= I18n.t('admin.members.not_in_mailchimp')
 
 
         .card

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -47,9 +47,11 @@ en:
     members:
       email: Emailaddress
       infix: Infix
+      mailinglists: Mailinglists
       members_per_page: members per page
       name: Name
       no_uu: This can not be an email from UU!
+      not_in_mailchimp: Member doesn't exist in Mailchimp
       phone: Phone number
       save_text: Please click on the save button to save your changes.
       show: Show

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -47,9 +47,11 @@ nl:
     members:
       email: E-mailadres
       infix: Tussenvoegsel
+      mailinglists: Mailinglijsten
       members_per_page: leden per pagina
       name: Voornaam
       no_uu: Dit kan niet een uu email zijn!
+      not_in_mailchimp: Lid bestaat niet in Mailchimp
       phone: Telefoonnummer
       save_text: Om een wijziging door te voeren moet je op de opslaan knop drukken.
       show: Toon


### PR DESCRIPTION
On the admin side there was an untranslated string above the mailchimp interests list.
Additionally, a message is now displayed when a member doesn't exist in mailchimp.