### PR TITLE
Fixed calendar copy link

### DIFF
--- a/app/assets/javascripts/members/activities/activities.js
+++ b/app/assets/javascripts/members/activities/activities.js
@@ -8,7 +8,7 @@ function Copy_ICS() {
   /* Link to copy */
 
   var copy_text =
-    "webcal://calendar.google.com/calendar/ical/stickyutrecht.nl_thvhicj5ijouaacp1elsv1hceo%40group.calendar.google.com/public/basic.ics";
+    "https://calendar.google.com/calendar/ical/stickyutrecht.nl_thvhicj5ijouaacp1elsv1hceo%40group.calendar.google.com/public/basic.ics";
 
   /* create a new element */
   var el = document.createElement("textarea");


### PR DESCRIPTION
I'm not even sure which applications use webcal as protocol. As far as I've seen using https is best practice and just gets you the .ics file :)