### PR TITLE
Make method of flash translation consistent

### DIFF
--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -76,10 +76,10 @@ class Members::HomeController < ApplicationController
 
       cookies["locale"] = @user.language
 
-      # use the translation location instead of the actual translated string so
-      # the correct translation can be displayed if the user changed the language
-      flash[:warning] = 'members.home.edit.email_confirmation' if @member.email != params[:member][:email]
-      redirect_to users_edit_path, :notice => 'members.home.edit.profile_saved'
+      # the translation location was used here but that conflicted with the way
+      # the translation was shown, as it was tried to translate it again there
+      flash[:warning] = I18n.t('members.home.edit.email_confirmation') if @member.email != params[:member][:email]
+      redirect_to users_edit_path, :notice => I18n.t('members.home.edit.profile_saved')
       return
     end
 

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -14,10 +14,10 @@
 
   - if flash[:notice]
     .alert.alert-success
-      %span= I18n.t(flash[:notice])
+      %span= flash[:notice]
   - if flash[:warning]
     .alert.alert-warning
-      %span= I18n.t(flash[:warning])
+      %span= flash[:warning]
 
   .row
     .col-xl-6


### PR DESCRIPTION
Closes #745 
The strings passed to `flash` are now always translated before they are passed.