### PR TITLE
Disable NFC cards

### DIFF
--- a/app/assets/javascripts/admin/members.js
+++ b/app/assets/javascripts/admin/members.js
@@ -193,6 +193,7 @@ $(document).on("ready page:load turbolinks:load", function () {
       if (tobeactivated) {
         status.removeClass('text-info');
         $(this).removeClass('activate btn-primary');
+        row.attr("data-active", 1);
       } else if (disabled) {
         status.removeClass('text-muted');
         $(this).removeClass('reactivate btn-warning');

--- a/app/assets/javascripts/admin/members.js
+++ b/app/assets/javascripts/admin/members.js
@@ -174,7 +174,7 @@ $(document).on("ready page:load turbolinks:load", function () {
     let entry = "admin.cards." + (tobeactivated ? "" : (disabled ? "re" : "de")) + "activate_confirm";
     if (!confirm(I18n.t(entry, { uuid: uuid }))) return;
 
-    let url = tobeactivated ? "/apps/card"
+    let url = tobeactivated ? "/apps/cards"
       : "/members/" + memberid + "/set_card_disabled/" + uuid;
     let successmsg = tobeactivated ? I18n.t("checkout.card.activated")
       : (disabled ? I18n.t("admin.cards.activate_success", { uuid: uuid })

--- a/app/assets/javascripts/admin/members.js
+++ b/app/assets/javascripts/admin/members.js
@@ -161,15 +161,27 @@ $(document).on("ready page:load turbolinks:load", function () {
 
   function deactivate() {
     let row = $(this).closest("tr");
-    let id = row.attr("data-id");
     let uuid = row.attr("data-uuid");
+    let memberid = row.attr("data-member-id");
     let token = encodeURIComponent(
-        $(this).closest(".page").attr("data-authenticity-token")
+      $(this).closest(".page").attr("data-authenticity-token")
     );
 
     if (!confirm(
-        I18n.t("admin.cards.deactivate_confirm",
-            { uuid: uuid })
+      I18n.t("admin.cards.deactivate_confirm", { uuid: uuid })
     )) return;
+
+    $.ajax({
+      url: "/members/" + memberid + "/delete_card/" + uuid,
+      type: "PATCH",
+      data: {
+        authenticity_token: token
+      }
+    }).done(() => {
+      toastr.success(I18n.t("admin.cards.deactivate_success", { uuid: uuid }));
+      row.remove();
+    }).fail(e => {
+      toastr.error(e.statusText, e.status);
+    })
   }
 });

--- a/app/assets/javascripts/admin/members.js
+++ b/app/assets/javascripts/admin/members.js
@@ -157,7 +157,7 @@ $(document).on("ready page:load turbolinks:load", function () {
 
   destroy(null);
 
-  $("#cards button").on("click", button_action);
+  $("#memberscards button").on("click", button_action);
 
   function button_action() {
     let row = $(this).closest("tr");

--- a/app/assets/javascripts/admin/members.js
+++ b/app/assets/javascripts/admin/members.js
@@ -161,7 +161,7 @@ $(document).on("ready page:load turbolinks:load", function () {
 
   function button_action() {
     let row = $(this).closest("tr");
-    let status = $(row).children('.cardstatus');
+    let status = $(row).children(".cardstatus");
     let uuid = row.attr("data-uuid");
     let memberid = row.attr("data-member-id");
     let token = encodeURIComponent(
@@ -171,14 +171,20 @@ $(document).on("ready page:load turbolinks:load", function () {
     let tobeactivated = row.attr("data-active") == 0;
     let disabled = row.attr("data-disabled") == 1;
 
-    let entry = "admin.cards." + (tobeactivated ? "" : (disabled ? "re" : "de")) + "activate_confirm";
+    let entry =
+      "admin.cards." +
+      (tobeactivated ? "" : disabled ? "re" : "de") +
+      "activate_confirm";
     if (!confirm(I18n.t(entry, { uuid: uuid }))) return;
 
-    let url = tobeactivated ? "/apps/cards"
+    let url = tobeactivated
+      ? "/apps/cards"
       : "/members/" + memberid + "/set_card_disabled/" + uuid;
-    let successmsg = tobeactivated ? I18n.t("checkout.card.activated")
-      : (disabled ? I18n.t("admin.cards.activate_success", { uuid: uuid })
-        : I18n.t("admin.cards.deactivate_success", { uuid: uuid }))
+    let successmsg = tobeactivated
+      ? I18n.t("checkout.card.activated")
+      : disabled
+      ? I18n.t("admin.cards.activate_success", { uuid: uuid })
+      : I18n.t("admin.cards.deactivate_success", { uuid: uuid });
 
     $.ajax({
       url: url,
@@ -186,35 +192,49 @@ $(document).on("ready page:load turbolinks:load", function () {
       data: {
         authenticity_token: token,
         uuid: uuid, // only needed for 'to be activated',
-        to: !disabled // only needed for toggling 'disabled'
-      }
-    }).done(() => {
-      // Remove current classes
-      if (tobeactivated) {
-        status.removeClass('text-info');
-        $(this).removeClass('activate btn-primary');
-        row.attr("data-active", 1);
-      } else if (disabled) {
-        status.removeClass('text-muted');
-        $(this).removeClass('reactivate btn-warning');
-      } else {
-        $(this).removeClass('deacticate btn-danger');
-      }
-      // Add new classes & content
-      if (disabled ^ tobeactivated) {
-        status.empty().append(I18n.t("admin.cards.active"));
-        $(this).empty().append('<i class="fa fa-trash"></i>' + I18n.t("admin.cards.deactivate"))
-          .addClass('deactivate btn-danger');
-        row.attr("data-disabled", 0);
-      } else {
-        status.empty().append(I18n.t("admin.cards.deactivated")).addClass('text-muted');
-        $(this).empty().append('<i class="fa fa-sync-alt"></i>' + I18n.t("admin.cards.reactivate"))
-          .addClass('reactivate btn-warning');
-        row.attr("data-disabled", 1);
-      }
-      toastr.success(successmsg);
-    }).fail(e => {
-      toastr.error(e.statusText, e.status);
+        to: !disabled, // only needed for toggling 'disabled'
+      },
     })
+      .done(() => {
+        // Remove current classes
+        if (tobeactivated) {
+          status.removeClass("text-info");
+          $(this).removeClass("activate btn-primary");
+          row.attr("data-active", 1);
+        } else if (disabled) {
+          status.removeClass("text-muted");
+          $(this).removeClass("reactivate btn-warning");
+        } else {
+          $(this).removeClass("deacticate btn-danger");
+        }
+        // Add new classes & content
+        if (disabled ^ tobeactivated) {
+          status.empty().append(I18n.t("admin.cards.active"));
+          $(this)
+            .empty()
+            .append(
+              '<i class="fa fa-trash"></i>' + I18n.t("admin.cards.deactivate")
+            )
+            .addClass("deactivate btn-danger");
+          row.attr("data-disabled", 0);
+        } else {
+          status
+            .empty()
+            .append(I18n.t("admin.cards.deactivated"))
+            .addClass("text-muted");
+          $(this)
+            .empty()
+            .append(
+              '<i class="fa fa-sync-alt"></i>' +
+                I18n.t("admin.cards.reactivate")
+            )
+            .addClass("reactivate btn-warning");
+          row.attr("data-disabled", 1);
+        }
+        toastr.success(successmsg);
+      })
+      .fail((e) => {
+        toastr.error(e.statusText, e.status);
+      });
   }
 });

--- a/app/assets/javascripts/admin/members.js
+++ b/app/assets/javascripts/admin/members.js
@@ -156,4 +156,20 @@ $(document).on("ready page:load turbolinks:load", function () {
   });
 
   destroy(null);
+
+  $("#cards button.deactivate").on("click", deactivate);
+
+  function deactivate() {
+    let row = $(this).closest("tr");
+    let id = row.attr("data-id");
+    let uuid = row.attr("data-uuid");
+    let token = encodeURIComponent(
+        $(this).closest(".page").attr("data-authenticity-token")
+    );
+
+    if (!confirm(
+        I18n.t("admin.cards.deactivate_confirm",
+            { uuid: uuid })
+    )) return;
+  }
 });

--- a/app/assets/stylesheets/admin/activities.css
+++ b/app/assets/stylesheets/admin/activities.css
@@ -7,7 +7,8 @@
 }
 
 #paymentmails tr > td,
-#participants tr > td {
+#participants tr > td,
+#cards tr > td {
   padding: 0 0 0 8px;
   vertical-align: middle;
 }
@@ -44,7 +45,8 @@
   width: calc(60% - 50px);
 }
 
-#participants tr > td > .btn-group {
+#participants tr > td > .btn-group,
+#cards tr > td > .btn-group {
   height: 30px;
   float: right;
   margin: 2px 0 4px 0;
@@ -52,7 +54,12 @@
   display: flex;
 }
 
-#participants tr > td > .btn-group > button {
+#cards tr > td > .btn-group {
+  margin-right: 3px;
+}
+
+#participants tr > td > .btn-group > button,
+#cards tr > td > .btn-group > button {
   height: 32px;
   line-height: 20px;
   padding: 5px 12px;

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -150,10 +150,11 @@ class Admin::MembersController < ApplicationController
     render layout: false, content_type: "text/plain"
   end
 
-  def delete_card
+  def set_card_disabled
     @uuid = params[:uuid]
+    @to = params[:to]
     @card = CheckoutCard.find_by(uuid: @uuid)
-    @card.update(disabled: true)
+    @card.update(disabled: @to)
   end
 
   private

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -150,6 +150,12 @@ class Admin::MembersController < ApplicationController
     render layout: false, content_type: "text/plain"
   end
 
+  def delete_card
+    @uuid = params[:uuid]
+    @card = CheckoutCard.find_by(uuid: @uuid)
+    @card.update(disabled: true)
+  end
+
   private
 
   def member_post_params

--- a/app/controllers/api/checkout_controller.rb
+++ b/app/controllers/api/checkout_controller.rb
@@ -126,6 +126,7 @@ class Api::CheckoutController < ActionController::Base
   end
 
   def authenticate_card
+    render status: :not_found if @card.nil?
     @uuid = params[:uuid]
     @card = CheckoutCard.find_by(uuid: @uuid)
     render status: :unauthorized, json: I18n.t('checkout.error.not_activated') unless @card.active

--- a/app/controllers/api/checkout_controller.rb
+++ b/app/controllers/api/checkout_controller.rb
@@ -3,6 +3,7 @@
 class Api::CheckoutController < ActionController::Base
   protect_from_forgery except: %i[info purchase create products recent]
   before_action :authenticate_checkout, only: %i[info purchase create products recent]
+  before_action :authenticate_card, only: %i[info purchase]
 
   respond_to :json
 
@@ -28,20 +29,10 @@ class Api::CheckoutController < ActionController::Base
     @card = CheckoutCard.joins(:member, :checkout_balance).select(:id, :uuid, :first_name, :balance, :active).find_by(uuid: params[:uuid])
 
     return head :not_found unless @card
-
-    unless @card.active
-      render status: :unauthorized, json: 'card not yet activated'
-      return
-    end
   end
 
   def purchase
     card = CheckoutCard.find_by_uuid!(params[:uuid])
-
-    unless card.active
-      render status: :unauthorized, json: I18n.t('checkout.error.not_activated')
-      return
-    end
 
     transaction = CheckoutTransaction.new(items: ahelper(params[:items]), checkout_card: card)
 
@@ -132,5 +123,13 @@ class Api::CheckoutController < ActionController::Base
       head :forbidden
       nil
     end
+  end
+
+  def authenticate_card
+    @uuid = params[:uuid]
+    @card = CheckoutCard.find_by(uuid: @uuid)
+    render status: :unauthorized, json: I18n.t('checkout.error.not_activated') unless @card.active
+    render status: :unauthorized, json: I18n.t('checkout.error.disabled') if @card.disabled
+    (@card.active and !@card.disabled)
   end
 end

--- a/app/controllers/api/checkout_controller.rb
+++ b/app/controllers/api/checkout_controller.rb
@@ -126,9 +126,9 @@ class Api::CheckoutController < ActionController::Base
   end
 
   def authenticate_card
-    render status: :not_found if @card.nil?
     @uuid = params[:uuid]
     @card = CheckoutCard.find_by(uuid: @uuid)
+    render status: :not_found && return if @card.nil?
     render status: :unauthorized, json: I18n.t('checkout.error.not_activated') unless @card.active
     render status: :unauthorized, json: I18n.t('checkout.error.disabled') if @card.disabled
     (@card.active and !@card.disabled)

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -258,16 +258,25 @@
           %table.table.table-striped#cards
             %tbody
               - @member.checkout_cards.each do |card|
-                %tr{ :data => { :uuid => card.uuid, :member_id => @member.id } }
+                %tr{ :data => { :uuid => card.uuid, :member_id => @member.id, :active => card.active ? 1 : 0, :disabled => card.disabled ? 1 : 0 } }
                   %td= card.uuid
                   - if !card.active
-                    %td.text-info= I18n.t('admin.cards.to_be_activated')
+                    %td.cardstatus.text-info= I18n.t('admin.cards.to_be_activated')
                   - elsif card.disabled
-                    %td.text-muted= I18n.t('admin.cards.deactivated')
+                    %td.cardstatus.text-muted= I18n.t('admin.cards.deactivated')
                   - else
-                    %td= I18n.t('admin.cards.active')
+                    %td.cardstatus= I18n.t('admin.cards.active')
                   %td
                     .btn-group
-                      %button.btn.btn-danger.deactivate
-                        %i.fa.fa-trash
-                        = I18n.t('admin.cards.deactivate')
+                      - if !card.active
+                        %button.btn.btn-primary.activate
+                          %i.fa.fa-check-circle
+                          = I18n.t('admin.cards.activate')
+                      - elsif card.disabled
+                        %button.btn.btn-warning.reactivate
+                          %i.fa.fa-sync-alt
+                          = I18n.t('admin.cards.reactivate')
+                      - else
+                        %button.btn.btn-danger.deactivate
+                          %i.fa.fa-trash
+                          = I18n.t('admin.cards.deactivate')

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -255,7 +255,7 @@
           .card-header
             %i.fa.fa-fw.fa-credit-card
             = I18n.t('admin.cards.cards')
-          %table.table.table-striped#cards
+          %table.table.table-striped#memberscards
             %tbody
               - @member.checkout_cards.each do |card|
                 %tr{ :data => { :uuid => card.uuid, :member_id => @member.id, :active => card.active ? 1 : 0, :disabled => card.disabled ? 1 : 0 } }

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -249,3 +249,19 @@
                           %i.fa.fa-fw.fa-times
                       %button.btn.btn-default.destroy
                         %i.fa.fa-fw.fa-trash
+
+
+        .card
+          .card-header
+            %i.fa.fa-fw.fa-credit-card
+            = I18n.t('admin.cards.cards')
+          %table.table.table-striped#cards
+            %tbody
+              - @member.checkout_cards.each do |card|
+                %tr
+                  %td= card.uuid
+                  %td
+                    .btn-group
+                      %button.btn.btn-danger
+                        %i.fa.fa-trash
+                        = I18n.t('admin.cards.deactivate')

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -258,8 +258,14 @@
           %table.table.table-striped#cards
             %tbody
               - @member.checkout_cards.each do |card|
-                %tr{ :data => { :id => card.id, :uuid => card.uuid } }
+                %tr{ :data => { :uuid => card.uuid, :member_id => @member.id } }
                   %td= card.uuid
+                  - if !card.active
+                    %td.text-info= I18n.t('admin.cards.to_be_activated')
+                  - elsif card.disabled
+                    %td.text-muted= I18n.t('admin.cards.deactivated')
+                  - else
+                    %td= I18n.t('admin.cards.active')
                   %td
                     .btn-group
                       %button.btn.btn-danger.deactivate

--- a/app/views/admin/members/show.html.haml
+++ b/app/views/admin/members/show.html.haml
@@ -258,10 +258,10 @@
           %table.table.table-striped#cards
             %tbody
               - @member.checkout_cards.each do |card|
-                %tr
+                %tr{ :data => { :id => card.id, :uuid => card.uuid } }
                   %td= card.uuid
                   %td
                     .btn-group
-                      %button.btn.btn-danger
+                      %button.btn.btn-danger.deactivate
                         %i.fa.fa-trash
                         = I18n.t('admin.cards.deactivate')

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -15,6 +15,9 @@ en:
       save: Save activity?
       single: Activity
       title: Activities
+    cards:
+      cards: Cards
+      deactivate: Deactivate
     error:
       invalid_values: Oops, not everything was filled in correctly
     front:

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -16,9 +16,13 @@ en:
       single: Activity
       title: Activities
     cards:
+      active: Active
       cards: Cards
       deactivate: Deactivate
       deactivate_confirm: Do you want to deactive and remove card %{uuid}?
+      deactivate_success: Card %{uuid} was deactivated
+      deactivated: Deactivated
+      to_be_activated: To be activated
     error:
       invalid_values: Oops, not everything was filled in correctly
     front:

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -18,6 +18,7 @@ en:
     cards:
       cards: Cards
       deactivate: Deactivate
+      deactivate_confirm: Do you want to deactive and remove card %{uuid}?
     error:
       invalid_values: Oops, not everything was filled in correctly
     front:

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -16,12 +16,18 @@ en:
       single: Activity
       title: Activities
     cards:
+      activate: Activate
+      activate_confirm: Do you want to activate card %{uuid}?
+      activate_success: Card %{uuid} was activated
       active: Active
       cards: Cards
       deactivate: Deactivate
-      deactivate_confirm: Do you want to deactive and remove card %{uuid}?
+      deactivate_confirm: Do you want to deactivate card %{uuid}?
       deactivate_success: Card %{uuid} was deactivated
       deactivated: Deactivated
+      reactivate: Reactivate
+      reactivate_confirm: Do you want to reactivate card %{uuid}?
+      reactivate_success: Card %{uuid} was reactivated
       to_be_activated: To be activated
     error:
       invalid_values: Oops, not everything was filled in correctly

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -15,6 +15,9 @@ nl:
       save: Activiteit opslaan?
       single: Activiteit
       title: Activiteiten
+    cards:
+      cards: Kaarten
+      deactivate: Deactiveer
     error:
       invalid_values: Oeps, niet alles is goed ingevuld
     front:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -16,9 +16,13 @@ nl:
       single: Activiteit
       title: Activiteiten
     cards:
+      active: Actief
       cards: Kaarten
       deactivate: Deactiveer
       deactivate_confirm: Kaart %{uuid} deactiveren en verwijderen?
+      deactivate_success: Kaart %{uuid} is gedeactiveerd
+      deactivated: Gedeactiveerd
+      to_be_activated: Nog niet geactiveerd
     error:
       invalid_values: Oeps, niet alles is goed ingevuld
     front:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -16,12 +16,18 @@ nl:
       single: Activiteit
       title: Activiteiten
     cards:
+      activate: Activeer
+      activate_confirm: Kaart %{uuid} activeren?
+      activate_success: Kaart %{uuid} is geactiveerd
       active: Actief
       cards: Kaarten
       deactivate: Deactiveer
-      deactivate_confirm: Kaart %{uuid} deactiveren en verwijderen?
+      deactivate_confirm: Kaart %{uuid} deactiveren?
       deactivate_success: Kaart %{uuid} is gedeactiveerd
       deactivated: Gedeactiveerd
+      reactivate: Reactiveer
+      reactivate_confirm: Kaart %{uuid} heractiveren?
+      reactivate_success: Kaart %{uuid} is heractiveerd
       to_be_activated: Nog niet geactiveerd
     error:
       invalid_values: Oeps, niet alles is goed ingevuld

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -18,6 +18,7 @@ nl:
     cards:
       cards: Kaarten
       deactivate: Deactiveer
+      deactivate_confirm: Kaart %{uuid} deactiveren en verwijderen?
     error:
       invalid_values: Oeps, niet alles is goed ingevuld
     front:

--- a/config/locales/checkout.en.yml
+++ b/config/locales/checkout.en.yml
@@ -14,6 +14,7 @@ en:
       removed: Card removed
       to_be_activated: To be activated cards
     error:
+      disabled: Card was deactivated
       identifier: No identifier given
       not_activated: Card is not yet activated
       numeric: The amount should be numeric

--- a/config/locales/checkout.en.yml
+++ b/config/locales/checkout.en.yml
@@ -10,7 +10,7 @@ en:
       not_activated: Card could not be activated!
       not_found: No card was found
       not_removed: Card was not removed
-      remove: verwijder
+      remove: remove
       removed: Card removed
       to_be_activated: To be activated cards
     error:

--- a/config/locales/checkout.nl.yml
+++ b/config/locales/checkout.nl.yml
@@ -14,6 +14,7 @@ nl:
       removed: Kaart verwijderd
       to_be_activated: Niet geactiveerde kaarten
     error:
+      disabled: Kaart is gedeactiveerd
       identifier: Geen ID gegeven
       not_activated: Kaart is nog niet geactiveerd
       numeric: Het bedrag moet numeriek zijn

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
         get   'payment_whatsapp'
         patch 'force_email_change'
         post  'email/:type', to: 'members#send_email', as: :mail
+        patch 'delete_card/:uuid', to: 'members#delete_card', as: 'delete_card'
 
         collection do
           get 'search'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
         get   'payment_whatsapp'
         patch 'force_email_change'
         post  'email/:type', to: 'members#send_email', as: :mail
-        patch 'delete_card/:uuid', to: 'members#delete_card', as: 'delete_card'
+        patch 'set_card_disabled/:uuid', to: 'members#set_card_disabled', as: 'set_card_disabled'
 
         collection do
           get 'search'

--- a/db/migrate/20210309155656_add_disabled_to_checkout_cards.rb
+++ b/db/migrate/20210309155656_add_disabled_to_checkout_cards.rb
@@ -1,0 +1,9 @@
+class AddDisabledToCheckoutCards < ActiveRecord::Migration[6.0]
+  def up
+    add_column :checkout_cards, :disabled, :boolean, default: false
+  end
+
+  def down
+    remove_column :checkout_cards, :disabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_05_212139) do
+ActiveRecord::Schema.define(version: 2021_03_09_155656) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2020_05_05_212139) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "confirmation_token"
+    t.boolean "disabled", default: false
     t.index ["uuid"], name: "index_checkout_cards_on_uuid", unique: true
   end
 


### PR DESCRIPTION
Closes #453 

Adds a new table (card) to the member overview, in which the member's cards can be seen. 
For each card, the UUID is shown and its status next to that.

From this overview, you can:
- Activate cards that have not been activated yet
- Deactivate cards
- Reactivate deactivated cards