### PR TITLE
Query for non-existent user after destroy

### DIFF
--- a/app/views/admin/settings/logs.html.haml
+++ b/app/views/admin/settings/logs.html.haml
@@ -36,7 +36,7 @@
             %tr
               %td= I18n.l impression.created_at
               %td
-                - if !impression.user_id.nil? && impression.action_name != "destroy"
+                - if !impression.user_id.nil? && User.find(impression.user_id).exists?
                   = User.find( impression.user_id ).email
               %td
                 - if ['Member', 'Group', 'Activity'].include? impression.impressionable_type

--- a/app/views/admin/settings/logs.html.haml
+++ b/app/views/admin/settings/logs.html.haml
@@ -36,7 +36,7 @@
             %tr
               %td= I18n.l impression.created_at
               %td
-                - if !impression.user_id.nil?
+                - if !impression.user_id.nil? && impression.action_name != "destroy"
                   = User.find( impression.user_id ).email
               %td
                 - if ['Member', 'Group', 'Activity'].include? impression.impressionable_type


### PR DESCRIPTION
When the user deletes their account the impressionist page tries to query the user but fails and makes the entire page fail. This should fix it.