### PR TITLE
Darktheme login

### DIFF
--- a/app/assets/stylesheets/doorkeeper.css
+++ b/app/assets/stylesheets/doorkeeper.css
@@ -9,5 +9,4 @@
  * compiled file, but it's generally better to create a new file per style scope.
  *
  *= require font_awesome5_webfont
- *= require bootstrap/dist/css/bootstrap
  */

--- a/app/javascript/stylesheets/doorkeeper.scss
+++ b/app/javascript/stylesheets/doorkeeper.scss
@@ -6,8 +6,12 @@
   @apply bg-blue-500 text-white p-2 rounded w-full;
 }
 
-.alert {
-  @apply bg-red-100 text-red-900 p-2 rounded;
+.alert-danger {
+  @apply bg-red-100 text-red-900 p-2 rounded dark:bg-red-900 dark:text-red-100;
+}
+
+.alert-info {
+  @apply bg-blue-100 text-blue-900 p-2 rounded dark:bg-blue-900 dark:text-blue-100;
 }
 
 .form-group {

--- a/app/javascript/stylesheets/doorkeeper.scss
+++ b/app/javascript/stylesheets/doorkeeper.scss
@@ -19,13 +19,21 @@
 }
 
 .input-group-prepend {
-    @apply w-12 flex bg-gray-200 rounded-l border border-gray-300;
+    @apply w-12 flex bg-gray-200 rounded-l border border-gray-300 dark:bg-gray-700 dark:border-black dark:text-white;
 }
 
 .form-control {
-    @apply py-2 px-4 rounded-r border border-l-0 border-gray-300 w-full;
+    @apply py-2 px-4 rounded-r border border-l-0 border-gray-300 w-full dark:bg-gray-600 dark:border-black dark:text-white;
 }
 
 .input-group-text {
     @apply m-auto;
+}
+
+// This is a hack because browsers do not follow the CSS standard with respect to specifity of display rules
+// see: https://stackoverflow.com/questions/68206422/tailwinds-darkhidden-darkblock-wont-override-its-own-hidden-selector
+@media (prefers-color-scheme: dark) {
+    .dark\:block {
+      display: block;
+    }
 }

--- a/app/javascript/stylesheets/doorkeeper.scss
+++ b/app/javascript/stylesheets/doorkeeper.scss
@@ -7,33 +7,33 @@
 }
 
 .alert {
-    @apply bg-red-100 text-red-900 p-2 rounded;
+  @apply bg-red-100 text-red-900 p-2 rounded;
 }
 
 .form-group {
-    @apply py-2;
+  @apply py-2;
 }
 
 .input-group {
-    @apply flex;
+  @apply flex;
 }
 
 .input-group-prepend {
-    @apply w-12 flex bg-gray-200 rounded-l border border-gray-300 dark:bg-gray-700 dark:border-black dark:text-white;
+  @apply w-12 flex bg-gray-200 rounded-l border border-gray-300 dark:bg-gray-700 dark:border-black dark:text-white;
 }
 
 .form-control {
-    @apply py-2 px-4 rounded-r border border-l-0 border-gray-300 w-full dark:bg-gray-600 dark:border-black dark:text-white;
+  @apply py-2 px-4 rounded-r border border-l-0 border-gray-300 w-full dark:bg-gray-600 dark:border-black dark:text-white;
 }
 
 .input-group-text {
-    @apply m-auto;
+  @apply m-auto;
 }
 
 // This is a hack because browsers do not follow the CSS standard with respect to specifity of display rules
 // see: https://stackoverflow.com/questions/68206422/tailwinds-darkhidden-darkblock-wont-override-its-own-hidden-selector
 @media (prefers-color-scheme: dark) {
-    .dark\:block {
-      display: block;
-    }
+  .dark\:block {
+    display: block;
+  }
 }

--- a/app/javascript/stylesheets/doorkeeper.scss
+++ b/app/javascript/stylesheets/doorkeeper.scss
@@ -11,7 +11,7 @@
 }
 
 .form-group {
-    @apply py-4;
+    @apply py-2;
 }
 
 .input-group {
@@ -23,7 +23,7 @@
 }
 
 .form-control {
-    @apply py-2 px-4 rounded-r border border-l-0 border-gray-300;
+    @apply py-2 px-4 rounded-r border border-l-0 border-gray-300 w-full;
 }
 
 .input-group-text {

--- a/app/javascript/stylesheets/doorkeeper.scss
+++ b/app/javascript/stylesheets/doorkeeper.scss
@@ -1,3 +1,31 @@
 @import "@tailwindcss/postcss7-compat/base";
 @import "@tailwindcss/postcss7-compat/components";
 @import "@tailwindcss/postcss7-compat/utilities";
+
+.btn {
+  @apply bg-blue-500 text-white p-2 rounded w-full;
+}
+
+.alert {
+    @apply bg-red-100 text-red-900 p-2 rounded;
+}
+
+.form-group {
+    @apply py-4;
+}
+
+.input-group {
+    @apply flex;
+}
+
+.input-group-prepend {
+    @apply w-12 flex bg-gray-200 rounded-l border border-gray-300;
+}
+
+.form-control {
+    @apply py-2 px-4 rounded-r border border-l-0 border-gray-300;
+}
+
+.input-group-text {
+    @apply m-auto;
+}

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -30,7 +30,7 @@
         = f.submit I18n.t 'devise.confirmations.new.submit', :class => 'btn btn-primary btn-block'
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
     |
     = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -40,7 +40,7 @@
         = f.submit I18n.t('devise.passwords.edit.change_password'), :class => 'btn btn-primary btn-block'
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
     |
     = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,4 +1,4 @@
-%h1.text-center.text-2xl.mb-2
+%h1.text-center.text-2xl.mb-2.dark:text-white
   = t('devise.passwords.edit.change_password')
 
 .row
@@ -34,7 +34,7 @@
         = f.submit I18n.t('devise.passwords.new.submit'), :class => 'btn btn-primary btn-block'
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
     |
     = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -21,7 +21,7 @@
           = flash[:notice]
 
     %fieldset.w-full
-      %h4.my-1= I18n.t 'devise.passwords.new.instruction'
+      %h4.my-1.dark:text-gray-300= I18n.t 'devise.passwords.new.instruction'
 
       .form-group
         .input-group

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,4 @@
-%h1.text-center.text-2xl.mb-2
+%h1.text-center.text-2xl.mb-2.dark:text-white
   = t('devise.registrations.sign_up')
 
 .row
@@ -45,7 +45,7 @@
         = f.submit I18n.t('devise.registrations.new.submit'), :class => 'btn btn-primary btn-block'
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
     |
     = link_to (I18n.t 'devise.registrations.login'), new_user_session_path

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,4 @@
-%h1.text-center.text-2xl.mb-2
+%h1.text-center.text-2xl.mb-2.dark:text-white
   = t('devise.registrations.login')
 
 .row
@@ -35,7 +35,7 @@
           = f.password_field :password, autocomplete: 'off', placeholder: t('devise.placeholders.password'), :class => 'form-control'
       .form-group
         .center
-          %span
+          %span.dark:text-white
             = f.check_box :remember_me
             = f.label(:remember_me, I18n.t('devise.sessions.new.remember_me'), :class => 'remember_label')
 
@@ -43,7 +43,7 @@
         = f.submit I18n.t('devise.sessions.new.sign_in'), :class => 'btn btn-primary btn-block'
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
     |
     = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path

--- a/app/views/doorkeeper/authorizations/new.html.haml
+++ b/app/views/doorkeeper/authorizations/new.html.haml
@@ -36,7 +36,7 @@
         = submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-block"
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
     |
     = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path

--- a/app/views/doorkeeper/authorizations/show.html.haml
+++ b/app/views/doorkeeper/authorizations/show.html.haml
@@ -14,7 +14,7 @@
     %code#authorization_code= params[:code]
 
 .row
-  .text-center.mx-auto
+  .text-center.mx-auto.dark:text-white
     = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
     |
     = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path

--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -22,7 +22,7 @@
       .shadow.px-10.py-4.rounded-md.bg-white.mx-auto
 
         - if current_user.present?
-          %h2
+          %h2.mt-2
             =I18n.t('layouts.doorkeeper.hi')
             %b= current_user.credentials.first_name
             = I18n.t('layouts.doorkeeper.identity_confirmation', name: current_user.credentials.name)

--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -15,11 +15,12 @@
     = javascript_pack_tag 'doorkeeper', 'data-turbolinks-track': 'reload'
 
     = csrf_meta_tags
-  %body.h-full.flex.flex-col.bg-gray-100
+  %body.h-full.flex.flex-col.bg-gray-100.dark:bg-black
     .flex.flex-col.flex-grow.justify-center
-      %img.w-64.mx-auto.p-4{src:"https://public.svsticky.nl/logos/logo_compact_kleur.svg"}
+      %img.w-64.mx-auto.p-4.dark:hidden{src:"https://public.svsticky.nl/logos/logo_compact_kleur.svg"}
+      %img.w-64.mx-auto.p-4.hidden.dark:block{src:"https://public.svsticky.nl/logos/logo_compact_outline_wit.svg"}
 
-      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto
+      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto.dark:bg-gray-800
 
         - if current_user.present?
           %h2.mt-2

--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -19,7 +19,7 @@
     .flex.flex-col.flex-grow.justify-center
       %img.w-64.mx-auto.p-4{src:"https://public.svsticky.nl/logos/logo_compact_kleur.svg"}
 
-      .shadow.px-10.py-4.rounded-md.bg-gray-50.mx-auto
+      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto
 
         - if current_user.present?
           %h2

--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -15,11 +15,11 @@
     = javascript_pack_tag 'doorkeeper', 'data-turbolinks-track': 'reload'
 
     = csrf_meta_tags
-  %body.h-full.flex.flex-col.bg-light
+  %body.h-full.flex.flex-col.bg-gray-100
     .flex.flex-col.flex-grow.justify-center
       %img.w-64.mx-auto.p-4{src:"https://public.svsticky.nl/logos/logo_compact_kleur.svg"}
 
-      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto
+      .shadow.px-10.py-4.rounded-md.bg-gray-50.mx-auto
 
         - if current_user.present?
           %h2

--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -20,7 +20,7 @@
       %img.w-64.mx-auto.p-4.dark:hidden{src:"https://public.svsticky.nl/logos/logo_compact_kleur.svg"}
       %img.w-64.mx-auto.p-4.hidden.dark:block{src:"https://public.svsticky.nl/logos/logo_compact_outline_wit.svg"}
 
-      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto.dark:bg-gray-800.dark:shadow-
+      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto.dark:bg-gray-800.dark
 
         - if current_user.present?
           %h2.mt-2

--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -15,12 +15,12 @@
     = javascript_pack_tag 'doorkeeper', 'data-turbolinks-track': 'reload'
 
     = csrf_meta_tags
-  %body.h-full.flex.flex-col.bg-gray-100.dark:bg-black
+  %body.h-full.flex.flex-col.bg-gray-100.dark:bg-gray-900
     .flex.flex-col.flex-grow.justify-center
       %img.w-64.mx-auto.p-4.dark:hidden{src:"https://public.svsticky.nl/logos/logo_compact_kleur.svg"}
       %img.w-64.mx-auto.p-4.hidden.dark:block{src:"https://public.svsticky.nl/logos/logo_compact_outline_wit.svg"}
 
-      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto.dark:bg-gray-800
+      .shadow.px-10.py-4.rounded-md.bg-white.mx-auto.dark:bg-gray-800.dark:shadow-
 
         - if current_user.present?
           %h2.mt-2
@@ -32,7 +32,7 @@
 
         = yield
 
-      %span.p-2.text-black.mx-auto
+      %span.p-2.text-gray-500.mx-auto
         = "Koala " + ConstipatedKoala::Application::VERSION.to_s
 
     = render 'layouts/partials/footer'

--- a/app/views/layouts/partials/_footer.html.haml
+++ b/app/views/layouts/partials/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer.w-full.bg-gray-900.h-16.p-2
+%footer.w-full.bg-gray-900.h-16.p-2.dark:bg-gray-900
   .container.flex.justify-center
     .flex.m-auto.justify-center{ :class => "sm:w-1/3" }
       = link_to image_tag('//public.svsticky.nl/logos/hoofd_outline_wit.svg', {:style => 'height: 40px; width: 40px;'}), '//svsticky.nl', :target => '_blank'

--- a/app/views/layouts/partials/_footer.html.haml
+++ b/app/views/layouts/partials/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer.w-full.bg-gray-900.h-16.p-2.dark:bg-gray-900
+%footer.w-full.h-16.p-2.bg-gray-800
   .container.flex.justify-center
     .flex.m-auto.justify-center{ :class => "sm:w-1/3" }
       = link_to image_tag('//public.svsticky.nl/logos/hoofd_outline_wit.svg', {:style => 'height: 40px; width: 40px;'}), '//svsticky.nl', :target => '_blank'

--- a/app/views/layouts/partials/_footer.html.haml
+++ b/app/views/layouts/partials/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer.w-full.bg-gray-dark.h-16.p-2
+%footer.w-full.bg-gray-900.h-16.p-2
   .container.flex.justify-center
     .flex.m-auto.justify-center{ :class => "sm:w-1/3" }
       = link_to image_tag('//public.svsticky.nl/logos/hoofd_outline_wit.svg', {:style => 'height: 40px; width: 40px;'}), '//svsticky.nl', :target => '_blank'

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -50,7 +50,6 @@ default: &default
 
 development:
   <<: *default
-    # Staging depends on precompilation of packs prior to booting for performance.
   compile: true
 
   # Extract and emit a css file

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,6 +10,8 @@ module.exports = {
       },
       stage: 3
     }),
+    // don't purge css in development
+    process.env.NODE_ENV === 'development' ? null :
     require("@fullhuman/postcss-purgecss")({
       content: [
         "./app/**/*.haml",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'media',
   purge: [],
   theme: {
     extend: {
@@ -16,6 +17,10 @@ module.exports = {
       xl: '1200px',
     }
   },
-  variants: {},
+  variants: {
+    display: [
+      'dark'
+    ]
+  },
   plugins: [],
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,32 +1,10 @@
 module.exports = {
   purge: [],
   theme: {
-    extend: {},
-    colors: {
-      // these colors are copied from Yeti
-      board: 'fe7215',
-      transparent: 'transparent',
-      blue: '#008cba',
-      indigo: '#6610f2',
-      purple: '#6f42c1',
-      pink: '#e83e8c',
-      red: '#F04124',
-      orange: '#fd7e14',
-      yellow: '#E99002',
-      green: '#43ac6a',
-      teal: '#20c997',
-      cyan: '#5bc0de',
-      white: '#fff',
-      gray: '#888',
-      'gray-dark': '#333',
-      primary: '#008cba',
-      secondary: '#eee',
-      success: '#43ac6a',
-      info: '#5bc0d',
-      warning: '#E99002',
-      danger: '#F04124',
-      light: '#eee',
-      dark: '#222',
+    extend: {
+      colors: {
+        board: 'fe7215',
+      }
     },
     screens: {
       // these breakpoints are copied from Yeti


### PR DESCRIPTION
This completely removes Bootstrap from the Doorkeeper pages, replacing everything with Tailwind.
Also, it adds a beautiful dark theme for this pages.
I'm not a designer, suggestions for improvements are welcome.

There is a bit of duplication in the code, but it has been there for a while, so I'm not fixing it in this PR.
Someone should DRY up the different Doorkeeper / Devise screens however.

I removed the Yeti colors in favor of the default Tailwind colors.
This set of colors is just more complete (and I don't really care about Yeti's feelings).

Also included is a bit of Webpack config changes that I came across while developing.

TODO: 
- [ ] Test the pages thoroughly, there are A LOT of different screens and warnings and I have not checked every single one of them.
- [x] Fix subtitle color (for example in /password/new)
- [x] Use a non-black background

This is how the new dark theme looks like:
![image](https://user-images.githubusercontent.com/15868836/127344666-41b3704c-09eb-416a-8282-f6da1d14d678.png)
