### PR TITLE
updated nixpkgs to 21.05 branch

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-20.09",
+        "branch": "release-21.05",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5dae77322c74077e57487baf19b80717526e7bf",
-        "sha256": "0d00xknfay7paw7dnrdshpi5jldmh27b6g2n0j5lacz4km7ci3s5",
+        "rev": "16bf3980bfa0d8929639be93fa8491ebad9d61ec",
+        "sha256": "0azsnd2pjg53siv97n5l62j0c8b5whi5bd5a2wqz1sphkirf3cgq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b5dae77322c74077e57487baf19b80717526e7bf.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/16bf3980bfa0d8929639be93fa8491ebad9d61ec.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This updates the pinned `nixpkgs` branch, which in turn leads to the following updates:
- nodejs is updated from version 12 to 14
- ruby is updated from version 2.6 to 2.7
- imagemagick is updated from version 6 to 7

No other major versions have changed.
This should be checked somewhat thoroughly, as there might be deprecations in above packages.

This change is also in some of my other PR's, but this one is probably easier to merge.