### PR TITLE
Feature/enable search transactions

### DIFF
--- a/app/controllers/admin/apps_controller.rb
+++ b/app/controllers/admin/apps_controller.rb
@@ -14,6 +14,8 @@ class Admin::AppsController < ApplicationController
 
   def transactions
     @transactions = Payment.order(created_at: :desc)
+
+    @transactions = @transactions.search_by_name(params[:search]) unless params[:search].blank?
     @transactions = @transactions.where(transaction_type: params[:transaction_type]) unless params[:transaction_type].blank?
     @transactions = @transactions.where(payment_type: params[:payment_type]) unless params[:payment_type].blank?
     @transactions = @transactions.where(status: params[:status]) unless params[:status].blank?

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -24,6 +24,19 @@ class Payment < ApplicationRecord
 
   after_validation :request_payment, on: :create
 
+  include PgSearch::Model
+  pg_search_scope :search_by_name,
+                  against: [:trxid],
+                  associated_against: {
+                    member: [:first_name, :infix, :last_name]
+                  },
+                  using: {
+                    trigram: {
+                      only: [:first_name, :last_name, :trxid],
+                      threshold: 0.1
+                    }
+                  }
+
   def request_payment
     self.token = Digest::SHA256.hexdigest("#{ member.id }#{ Time.now.to_f }")
     self.amount += transaction_fee

--- a/app/views/layouts/partials/_search_payments.html.haml
+++ b/app/views/layouts/partials/_search_payments.html.haml
@@ -3,7 +3,7 @@
     .card.card-body
       = form_with url: paymenthandlers_path, method: 'get', local: true do |form|
         .input-group
-          = form.text_field :search,  placeholder: I18n.t('layouts.partials.search_payments.placeholder'), class: 'form-control', :autocomplete => 'off', :disabled => true
+          = form.text_field :search,  placeholder: I18n.t('layouts.partials.search_payments.placeholder'),  class: 'form-control', :autocomplete => 'off',value: params[:search] || ""
           .input-group-append
             .form-element
             %button.btn.btn-info.dropdown-toggle{'data-toggle' => "dropdown", 'aria-haspopup' => 'true', 'aria-expanded'=>'false'}= I18n.t('admin.transactions.payment_type.title')


### PR DESCRIPTION
Initially when transactions got added i didn't add the feature to search for transactions since the old search engine was soon to be removed. Since this has happened this feature should be added asap.

Possible TO-DO's:

- [ ] Search on activity name (Pretty sure this is close to impossible since we only store activity id's in a list)
- [ ] Add date range as possible search parameter
- [ ] When pressing enter you should search and not open the payment method list