### PR TITLE
FIX: Pin docker compose version to 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 'redis_data:/bitnami/redis/data'
 
   postgres-db:
-    image: postgres
+    image: postgres:13
     restart: always
     environment:
       POSTGRES_USER: koala


### PR DESCRIPTION
The postgres version in the docker compose file was unpinned, while this is not an issue right now, it will be when docker sees 14 as the latest. 