### PR TITLE
Schema format for application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,9 @@ module ConstipatedKoala
 
     config.active_job.queue_adapter = :sidekiq
 
+    # Enable raw sql in database migrations
+    config.active_record.schema_format = :sql
+
     # Custom configuration
     config.mailgun = ENV['MAILGUN_TOKEN']
     config.checkout = ENV['CHECKOUT_TOKEN']

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,9 +43,6 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Enable raw sql in database migrations
-  config.active_record.schema_format = :sql
-
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.


### PR DESCRIPTION
schema_format was only set for development. This should be set for all environments