### PR TITLE
Pin nix to version 2.3 to keep builds from failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
     - name: "install Nix"
       uses: cachix/install-nix-action@v12
+      with:
+        install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
     - name: "Cache Nix packages"
       uses: cachix/cachix-action@v8


### PR DESCRIPTION
Due to the release of Nix 2.4 (see svsticky/sadserver/issues/333), and the fact that the install-nix-action just updates Nix without warning, we need to pin the version of Nix in CI for the time being.