### PR TITLE
Payconiq removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, it implements methods to track several things within the association:
 
 - Members and membership status;
 - Activities and participants;
-- Payments via iDeal and Payconiq;
+- Payments via iDeal;
 - Committees and other groups;
 - Operation Dead Mongoose (TM) and Mongoose credit
 - [OAuth authentication](/app/controllers/api) and authorization endpoint;
@@ -29,7 +29,7 @@ Koala has an [api](/app/views/api), it is used by [Radio](https://github.com/svs
 Koala is quite a large program, and has many integrations.
 To test and use some of the functionality, access to external api's is needed.
 Credentials can be found in the IT Crowd or CommIT password managers.
-Most notably, Koala integrates with MailChimp, MailGun, Mollie and PayConiq.
+Most notably, Koala integrates with MailChimp, MailGun and Mollie.
 
 ```shell
 # Add hosts for different subdomains on your own computer for development

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -52,19 +52,19 @@ class Admin::PaymentsController < ApplicationController
   end
 
   def export_payments
-    return head(:bad_request) unless params[:export_type].present? && params[:payment_type].present? && params[:start_date].present? && params[:end_date].present?
+    return head(:bad_request) unless params[:export_type].present? && params[:start_date].present? && params[:end_date].present?
 
-    payment_type = [:ideal]
+    payment_type = :ideal
 
     @transaction_file = CSV.generate do |input|
       @payments = Payment.where(created_at: (Date.strptime(params[:start_date], "%Y-%m-%d")..Date.strptime(params[:end_date], "%Y-%m-%d")), payment_type: payment_type, status: :successful)
-      create_invoice(input, @payments, params[:payment_type], params[:start_date], params[:end_date])
+      create_invoice(input, @payments, payment_type, params[:start_date], params[:end_date])
     end
 
     respond_to do |format|
       format.html { redirect_to payments_path }
       format.csv { send_data @transaction_file, filename: "payments_#{ Date.strptime(params[:start_date], '%Y-%m-%d') }_#{ Date.strptime(params[:end_date], '%Y-%m-%d') }.csv" }
-      format.js { render js: "window.open(\"#{ transactions_export_path(format: :csv, start_date: params[:start_date], end_date: params[:end_date], payment_type: params[:payment_type], export_type: params[:export_type]) }\", \"_blank\")" }
+      format.js { render js: "window.open(\"#{ transactions_export_path(format: :csv, start_date: params[:start_date], end_date: params[:end_date], payment_type: payment_type, export_type: params[:export_type]) }\", \"_blank\")" }
     end
   end
 

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -23,7 +23,7 @@ class Admin::SettingsController < ApplicationController
         warning: params[:value].split(',').map(&:to_i).count != Settings[params[:setting]].count
       }
       return
-    elsif %w[mongoose_ideal_costs payconiq_transaction_costs].include? params[:setting]
+    elsif %w[mongoose_ideal_costs].include? params[:setting]
       head(:bad_request) && return if (params[:value] =~ /\d{1,}[,.]\d{2}/).nil?
 
       Settings[params[:setting]] = params[:value].sub(',', '.').to_f
@@ -35,7 +35,7 @@ class Admin::SettingsController < ApplicationController
       head(:bad_request) && return if (params[:value] =~ /\d{2}:\d{2}/).nil?
 
       Settings[params[:setting]] = params[:value]
-    elsif %w[payconiq_relation_code ideal_relation_code payment_condition_code mongoose_ledger_number accountancy_ledger_number].include? params[:setting]
+    elsif %w[ideal_relation_code payment_condition_code mongoose_ledger_number accountancy_ledger_number].include? params[:setting]
       head(:bad_request) && return if (params[:value] =~ /\d+/).nil?
 
       Settings[params[:setting]] = params[:value]

--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -34,7 +34,6 @@ class Members::HomeController < ApplicationController
              .order('start_date DESC')
 
     @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by_member_id(current_user.credentials_id)).order(created_at: :desc).limit(10) # ParticipantTransaction.all #
-    @payconiq_transaction_costs = Settings.payconiq_transaction_costs
     @transaction_costs = Settings.mongoose_ideal_costs
   end
 

--- a/app/controllers/members/payments_controller.rb
+++ b/app/controllers/members/payments_controller.rb
@@ -8,7 +8,6 @@ class Members::PaymentsController < ApplicationController
     @member = Member.find(current_user.credentials_id)
     @participants = @member.unpaid_activities
     @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by_member_id(current_user.credentials_id)).order(created_at: :desc).limit(10) # ParticipantTransaction.all #
-    @payconiq_transaction_costs = Settings.payconiq_transaction_costs
     @transaction_costs = Settings.mongoose_ideal_costs
   end
 

--- a/app/javascript/src/members/payments.js
+++ b/app/javascript/src/members/payments.js
@@ -1,24 +1,7 @@
 $(document).on("ready page:load turbolinks:load", function () {
   // Selects all the activities
 
-  $("#payment_type_add_funds").on("change", function () {
-    if (this.value == "Payconiq") {
-      $(".payconiq-mongoose").show();
-      $(".ideal-mongoose").hide();
-    } else {
-      $(".ideal-mongoose").show();
-      $(".payconiq-mongoose").hide();
-    }
-  });
-
   $("#payment_type_pay_activities").on("change", function () {
-    if (this.value == "Payconiq") {
-      $(".payconiq-activities").show();
-      $(".ideal-activities").hide();
-    } else {
-      $(".ideal-activities").show();
-      $(".payconiq-activities").hide();
-    }
     calculatetotals();
   });
   $("#payment_type_add_funds").change();

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -138,9 +138,11 @@ class Payment < ApplicationRecord
   def transaction_fee
     case payment_type.to_sym
     when :ideal
-      return Settings.mongoose_ideal_costs
+      Settings.mongoose_ideal_costs
+    when :payconiq_online
+      0
     when :pin
-      return 0
+      0
     end
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -12,7 +12,8 @@ class Payment < ApplicationRecord
   validates :payment_type, presence: true
 
   enum status: { failed: 0, in_progress: 1, successful: 2 }
-  enum payment_type: { ideal: 0, pin: 3 }
+  # Keep payconiq_online because it is still present in the database
+  enum payment_type: { ideal: 0, payconiq_online: 1, pin: 3 }
   enum transaction_type: { checkout: 0, activity: 1 }
   belongs_to :member
 

--- a/app/views/admin/payments/index.html.haml
+++ b/app/views/admin/payments/index.html.haml
@@ -104,9 +104,7 @@
                   =f.date_field :end_date, value: 1.days.from_now.strftime('%Y-%m-%d'), :class => "form-control", :required => true
               .row
               .row.form-group
-                .col-2
-                  = f.select :payment_type, ["Ideal"],{} ,{class:'form-control'}
-                .col-3
+                .col-5
                   = f.radio_button :export_type, "all", :checked => true
                   = f.label I18n.t('admin.payment.all')
                   = f.radio_button :export_type, "daily"

--- a/app/views/admin/payments/index.html.haml
+++ b/app/views/admin/payments/index.html.haml
@@ -105,7 +105,7 @@
               .row
               .row.form-group
                 .col-2
-                  = f.select :payment_type, ["Ideal","Payconiq"],{} ,{class:'form-control'}
+                  = f.select :payment_type, ["Ideal"],{} ,{class:'form-control'}
                 .col-3
                   = f.radio_button :export_type, "all", :checked => true
                   = f.label I18n.t('admin.payment.all')

--- a/app/views/admin/settings/index.html.haml
+++ b/app/views/admin/settings/index.html.haml
@@ -77,20 +77,6 @@
               %li.list-group-item
                 .container.row
                   .col-md-6
-                    %b= I18n.t 'payconiq_transaction_costs.name', scope: 'activerecord.attributes.settings'
-                    %p= I18n.t 'payconiq_transaction_costs.description', scope: 'activerecord.attributes.settings'
-                  .col-md-6
-                    %input.form-control{ :id => 'options_payconiq_transaction_costs', :name => 'payconiq_transaction_costs', :value => Settings.payconiq_transaction_costs, :placeholder => '' }
-              %li.list-group-item
-                .container.row
-                  .col-md-6
-                    %b= I18n.t 'payconiq_relation_code.name', scope: 'activerecord.attributes.settings'
-                    %p= I18n.t 'payconiq_relation_code.description', scope: 'activerecord.attributes.settings'
-                  .col-md-6
-                    %input.form-control{ :id => 'options_payconiq_relation_code', :name => 'payconiq_relation_code', :value => Settings.payconiq_relation_code, :placeholder => '' }
-              %li.list-group-item
-                .container.row
-                  .col-md-6
                     %b= I18n.t 'ideal_relation_code.name', scope: 'activerecord.attributes.settings'
                     %p= I18n.t 'ideal_relation_code.description', scope: 'activerecord.attributes.settings'
                   .col-md-6

--- a/app/views/members/payments/index.html.haml
+++ b/app/views/members/payments/index.html.haml
@@ -37,10 +37,6 @@
                 %tr
                   %td
                   %td
-                    = I18n.t("members.payments.unpaid_activity.footer.paymentmethod")
-                    .float-xl-right
-                      =f.select :payment_type, [["Ideal +€#{String(@transaction_costs)}", 'Ideal']], {},{:id => 'payment_type_pay_activities'}
-                  %td.d-none.d-xl-table-cell
                     = I18n.t("members.payments.unpaid_activity.footer.subtotal")
                   %td#subtotal_activities
                 %tr
@@ -49,19 +45,18 @@
                     .ideal-activities
                       =I18n.t("members.payments.unpaid_activity.footer.bank")
                       .float-xl-right= f.select :bank, options_for_select(Payment::ideal_issuers), {}, {style: '', class:'ideal-activities'}
-                  %td.d-none.d-xl-table-cell
-                    = I18n.t("members.payments.unpaid_activity.footer.transactioncosts")
-                  %td#transaction_cost_activities
+                  %td
+                    %div
+                      = I18n.t("members.payments.unpaid_activity.footer.transactioncosts")
                     %span.transaction_cost_activities.ideal-activities{:price =>@transaction_costs}= number_to_currency(@transaction_costs, :unit => '€')
                 %tr
-                  %td.d-none.d-xl-table-cell
-                  %td  
+                  %td
                   %td
                     %strong= I18n.t("members.payments.unpaid_activity.footer.total")
                   %td#total_activities
                 %tr
                   %td
-                  %td 
+                  %td
                   %td
                     = f.submit I18n.t("members.payments.unpaid_activity.pay"), class: 'button btn btn-success btn-sm activity-payment', type: "submit"
                   %td
@@ -117,9 +112,9 @@
                 %td
                 %td
               %tr
-                %td.home_mongoose_form_element= I18n.t("members.payments.unpaid_activity.footer.paymentmethod")
+                %td.home_mongoose_form_element= I18n.t("members.payments.unpaid_activity.footer.transactioncosts")
                 %td.home_mongoose_form_element
-                  = f.select :payment_type, [["Ideal +€#{String(@transaction_costs)}", 'Ideal']], {}, { :id => 'payment_type_add_funds' }
+                  = "€#{String(@transaction_costs)}"
                 %td.home_mongoose_form_element
               %tr
                 %td.home_mongoose_form_element

--- a/config/app.yml
+++ b/config/app.yml
@@ -2,10 +2,9 @@ defaults: &defaults
   # year doesn't matter as long as it is in the past, cronjob creates new date incrementing exactly one year
   begin_study_year: '2009-09-01'
 
-  payconiq_transaction_costs: 0.12
+
   mongoose_ideal_costs: 0.29
   liquor_time: '16:00'
-  payconiq_relation_code: "963"
   ideal_relation_code: "473"
   payment_condition_code: "02"
   mongoose_ledger_number: "8002"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,46 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "04ade6f355e595ec334a54c16157d4174338254b85c75a17b741279b30851b59",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/members/payments_controller.rb",
-      "line": 44,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Payment.new(:description => (\"#{\"Activiteiten - \"}#{self.class.join_with_char_limit(Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).map do\n p.activity.name\n end, \", \", (140 - \"Activiteiten - \".length))}\"), :amount => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).sum(&:currency), :issuer => transaction_params[:bank], :member => Member.find(current_user.credentials_id), :payment_type => :ideal, :transaction_id => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).pluck(:activity_id), :transaction_type => :activity, :redirect_uri => member_payments_path).payment_uri)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Members::PaymentsController",
-        "method": "pay_activities"
-      },
-      "user_input": "Payment.new(:description => (\"#{\"Activiteiten - \"}#{self.class.join_with_char_limit(Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).map do\n p.activity.name\n end, \", \", (140 - \"Activiteiten - \".length))}\"), :amount => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).sum(&:currency), :issuer => transaction_params[:bank], :member => Member.find(current_user.credentials_id), :payment_type => :ideal, :transaction_id => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).pluck(:activity_id), :transaction_type => :activity, :redirect_uri => member_payments_path).payment_uri",
-      "confidence": "High",
-      "note": "Have to redirect to get to mollie payment portal"
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "29914a5ab2e071e86f64854c9a7e76f0acc29b98485c33f42817d8cf6c5d1d69",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/public/home_controller.rb",
-      "line": 70,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Payment.new(:description => I18n.t(\"form.introduction\", :user => Member.new(public_post_params.except(:participant_attributes)).name), :amount => (0 + Participant.create(:member => Member.new(public_post_params.except(:participant_attributes)), :activity => activity).currency), :issuer => params[:bank], :member => Member.new(public_post_params.except(:participant_attributes)), :transaction_id => Activity.find(public_post_params[:participant_attributes].to_h.select do\n (participant[\"participate\"].nil? or (participant[\"participate\"].to_b == true))\n end.map do\n participant[\"id\"].to_i\n end).map(&:id), :transaction_type => :activity, :payment_type => :ideal, :redirect_uri => public_url).payment_uri)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Public::HomeController",
-        "method": "create"
-      },
-      "user_input": "Payment.new(:description => I18n.t(\"form.introduction\", :user => Member.new(public_post_params.except(:participant_attributes)).name), :amount => (0 + Participant.create(:member => Member.new(public_post_params.except(:participant_attributes)), :activity => activity).currency), :issuer => params[:bank], :member => Member.new(public_post_params.except(:participant_attributes)), :transaction_id => Activity.find(public_post_params[:participant_attributes].to_h.select do\n (participant[\"participate\"].nil? or (participant[\"participate\"].to_b == true))\n end.map do\n participant[\"id\"].to_i\n end).map(&:id), :transaction_type => :activity, :payment_type => :ideal, :redirect_uri => public_url).payment_uri",
-      "confidence": "High",
-      "note": "Have to redirect for payment"
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "3b8d54ccdfe03e13e9d1cd35e1640ed0a68e7505d339a35e79d8d25b531e6775",
@@ -133,26 +93,6 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "8c08dc71a8af936322aef7b0bb64fade45df68eaa90f7a0b077ed739749e8f00",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/api/webhook_controller.rb",
-      "line": 13,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Payment.find_by_token!(params[:token]).redirect_uri)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Api::WebhookController",
-        "method": "payment_redirect"
-      },
-      "user_input": "Payment.find_by_token!(params[:token]).redirect_uri",
-      "confidence": "High",
-      "note": "Required to validate transaction after coming back from the payment provider"
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
       "fingerprint": "9cc91332d5d2f54e3ae1b67048c6d1f5bc8a5fc6b55f64c789d04124b7d7a73f",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
@@ -207,6 +147,6 @@
       "note": "Brakeman parses version numbers incorrectly, thinking version 2.11.0 is equal to 2.1.1. The currently installed version of loofah is not vulnerable to CVE listed."
     }
   ],
-  "updated": "2022-01-03 13:23:22 +0100",
+  "updated": "2022-02-21 21:49:32 +0100",
   "brakeman_version": "4.8.2"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -20,26 +20,6 @@
       "note": "The admins can defs put code in their signature, we kinda trust our admins not to do this though"
     },
     {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "62cd8ff24cdeadc799dac0f8520b40aa94078756aaf273bcd6c9b97b5bb5dca5",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/members/payments_controller.rb",
-      "line": 103,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Payment.new(:description => I18n.t(\"activerecord.errors.models.payment.attributes.checkout\"), :amount => transaction_params[:amount].gsub(\",\", \".\").to_f, :member => Member.find(current_user.credentials_id), :issuer => transaction_params[:bank], :payment_type => :ideal, :transaction_id => nil, :transaction_type => :checkout, :redirect_uri => member_payments_path).payment_uri)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Members::PaymentsController",
-        "method": "add_funds"
-      },
-      "user_input": "Payment.new(:description => I18n.t(\"activerecord.errors.models.payment.attributes.checkout\"), :amount => transaction_params[:amount].gsub(\",\", \".\").to_f, :member => Member.find(current_user.credentials_id), :issuer => transaction_params[:bank], :payment_type => :ideal, :transaction_id => nil, :transaction_type => :checkout, :redirect_uri => member_payments_path).payment_uri",
-      "confidence": "High",
-      "note": "Have to redirect to mollie payment portal"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "7627b4a6d06014a919a69d798701940bc0938376d285cc17e9d6dbfde550f778",
@@ -147,6 +127,6 @@
       "note": "Brakeman parses version numbers incorrectly, thinking version 2.11.0 is equal to 2.1.1. The currently installed version of loofah is not vulnerable to CVE listed."
     }
   ],
-  "updated": "2022-02-21 21:49:32 +0100",
+  "updated": "2022-02-21 22:28:22 +0100",
   "brakeman_version": "4.8.2"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -106,7 +106,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/admin/settings/index.html.haml",
-      "line": 192,
+      "line": 151,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "current_user.credentials.signature",
       "render_path": [

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,26 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "04ade6f355e595ec334a54c16157d4174338254b85c75a17b741279b30851b59",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/members/payments_controller.rb",
+      "line": 43,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Payment.new(:description => (\"#{\"Activiteiten - \"}#{self.class.join_with_char_limit(Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).map do\n p.activity.name\n end, \", \", (140 - \"Activiteiten - \".length))}\"), :amount => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).sum(&:currency), :issuer => transaction_params[:bank], :member => Member.find(current_user.credentials_id), :payment_type => :ideal, :transaction_id => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).pluck(:activity_id), :transaction_type => :activity, :redirect_uri => member_payments_path).payment_uri)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Members::PaymentsController",
+        "method": "pay_activities"
+      },
+      "user_input": "Payment.new(:description => (\"#{\"Activiteiten - \"}#{self.class.join_with_char_limit(Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).map do\n p.activity.name\n end, \", \", (140 - \"Activiteiten - \".length))}\"), :amount => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).sum(&:currency), :issuer => transaction_params[:bank], :member => Member.find(current_user.credentials_id), :payment_type => :ideal, :transaction_id => Participant.where(:activity_id => params[:activity_ids], :member => Member.find(current_user.credentials_id), :reservist => false).joins(:activity).where(:activities => ({ :is_payable => true })).pluck(:activity_id), :transaction_type => :activity, :redirect_uri => member_payments_path).payment_uri",
+      "confidence": "High",
+      "note": "Needed for processing payments"
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "3b8d54ccdfe03e13e9d1cd35e1640ed0a68e7505d339a35e79d8d25b531e6775",
@@ -18,6 +38,26 @@
       "user_input": "current_user.credentials.signature",
       "confidence": "Weak",
       "note": "The admins can defs put code in their signature, we kinda trust our admins not to do this though"
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "62cd8ff24cdeadc799dac0f8520b40aa94078756aaf273bcd6c9b97b5bb5dca5",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/members/payments_controller.rb",
+      "line": 102,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Payment.new(:description => I18n.t(\"activerecord.errors.models.payment.attributes.checkout\"), :amount => transaction_params[:amount].gsub(\",\", \".\").to_f, :member => Member.find(current_user.credentials_id), :issuer => transaction_params[:bank], :payment_type => :ideal, :transaction_id => nil, :transaction_type => :checkout, :redirect_uri => member_payments_path).payment_uri)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Members::PaymentsController",
+        "method": "add_funds"
+      },
+      "user_input": "Payment.new(:description => I18n.t(\"activerecord.errors.models.payment.attributes.checkout\"), :amount => transaction_params[:amount].gsub(\",\", \".\").to_f, :member => Member.find(current_user.credentials_id), :issuer => transaction_params[:bank], :payment_type => :ideal, :transaction_id => nil, :transaction_type => :checkout, :redirect_uri => member_payments_path).payment_uri",
+      "confidence": "High",
+      "note": "Needed for processing payments"
     },
     {
       "warning_type": "SQL Injection",
@@ -73,6 +113,26 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
+      "fingerprint": "8c08dc71a8af936322aef7b0bb64fade45df68eaa90f7a0b077ed739749e8f00",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/api/webhook_controller.rb",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Payment.find_by_token!(params[:token]).redirect_uri)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::WebhookController",
+        "method": "payment_redirect"
+      },
+      "user_input": "Payment.find_by_token!(params[:token]).redirect_uri",
+      "confidence": "High",
+      "note": "Needed for processing payments"
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
       "fingerprint": "9cc91332d5d2f54e3ae1b67048c6d1f5bc8a5fc6b55f64c789d04124b7d7a73f",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
@@ -95,7 +155,7 @@
       "warning_code": 70,
       "fingerprint": "b80db455c4dd1ca640177dd5c9d1232eb638dbc2d29f46aababbaad11458f04f",
       "check_name": "MassAssignment",
-      "message": "Parameters should be whitelisted for mass assignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/admin/participants_controller.rb",
       "line": 52,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
@@ -109,24 +169,8 @@
       "user_input": null,
       "confidence": "Medium",
       "note": "The mass-assignment only is used to map over, the emailadresses will be checked later anyway"
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 106,
-      "fingerprint": "cdfb1541fdcc9cdcf0784ce5bd90013dc39316cb822eedea3f03b2521c06137f",
-      "check_name": "SanitizeMethods",
-      "message": "loofah gem 2.11.0 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1",
-      "file": "Gemfile.lock",
-      "line": 151,
-      "link": "https://github.com/flavorjones/loofah/issues/144",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "High",
-      "note": "Brakeman parses version numbers incorrectly, thinking version 2.11.0 is equal to 2.1.1. The currently installed version of loofah is not vulnerable to CVE listed."
     }
   ],
-  "updated": "2022-02-21 22:28:22 +0100",
-  "brakeman_version": "4.8.2"
+  "updated": "2022-03-29 22:14:59 +0200",
+  "brakeman_version": "5.2.1"
 }

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -109,8 +109,6 @@ en:
       not_paid: Unpaid for activities
       overdue: Overdue payments (> 4 mails)
       paid: Paid
-      payconiq_display: Payconiq display total
-      payconiq_online: Payconiq display total
       per_page: transactions per page
       pinned: Pinned Checkout transactions
       price: Price
@@ -159,8 +157,6 @@ en:
       member: Member
       payment_type:
         ideal: Ideal
-        payconiq_display: Payconiq display
-        payconiq_online: Payconiq online
         pin: Pinned
         title: Payment Method
       state:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -109,8 +109,7 @@ nl:
       not_paid: Niet betaalde activiteiten
       overdue: Achterstallige betalingen (> 4 mails)
       paid: Betaald
-      payconiq_display: Payconiq display totaalbedrag
-      payconiq_online: Payconiq online totaal
+
       per_page: transacties per pagina
       pinned: Gepinde Checkout transacties
       price: Prijs
@@ -159,8 +158,6 @@ nl:
       member: Lid
       payment_type:
         ideal: Ideal
-        payconiq_display: Payconiq display
-        payconiq_online: Payconiq online
         pin: Gepind
         title: Betaalmethode
       state:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -109,7 +109,6 @@ nl:
       not_paid: Niet betaalde activiteiten
       overdue: Achterstallige betalingen (> 4 mails)
       paid: Betaald
-
       per_page: transacties per pagina
       pinned: Gepinde Checkout transacties
       price: Prijs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,8 +152,6 @@ en:
           title: Payment status
         payment-type:
           ideal: Ideal
-          payconiq_display: Payconiq Checkout
-          payconiq_online: Payconiq Online
           pin: Pin
           title: Payment Types
         transaction-type:
@@ -194,12 +192,6 @@ en:
         mongoose_ledger_number:
           description: The ledger number of mongoose funds upgrades.  This number can be found in our finance account on ExactOnline.
           name: Mongoose ledger number
-        payconiq_relation_code:
-          description: The relation code of payconiq for the export transaction feature.  This code can be found in ExactOnline and is only relevant for the treasurer.
-          name: Payconiq Relation Code
-        payconiq_transaction_costs:
-          description: The costs of an Payconiq transaction. They can be calculated separately in the Payconiq overview this way.
-          name: Payconiq transaction costs
         payment_condition_code:
           description: The payment code for the export transaction feature. This code is used in ExactOnline.
           name: Payment Condition Code

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -152,8 +152,6 @@ nl:
           title: Betaling status
         payment-type:
           ideal: Ideal
-          payconiq_display: Payconiq Checkout
-          payconiq_online: Payconiq Online
           pin: Pin
           title: Betaling type
         transaction-type:
@@ -194,12 +192,6 @@ nl:
         mongoose_ledger_number:
           description: Het mongoose opwaarderingen grootboeknummer. Dit is nodig voor de export transacties functie en alleen relevant voor de penningmeester.
           name: Mongoose grootboekrekeningnummer
-        payconiq_relation_code:
-          description: De relatie code van Payconiq. Dit is nodig voor de export transacties functie en alleen relevant voor de penningmeester.
-          name: Payconiq relatienummer
-        payconiq_transaction_costs:
-          description: De kosten van een Payconiq-transactie, zodat deze apart kunnen worden berekend in het Payconiq-overzicht.
-          name: Payconiq transactie kosten
         payment_condition_code:
           description: De betalingsconditie. Dit is nodig voor de export transacties functie en alleen relevant voor de penningmeester.
           name: Betalingsconditie

--- a/db/seeds/payments.rb
+++ b/db/seeds/payments.rb
@@ -7,7 +7,7 @@ Member.all.sample(30).each do |member|
 
   15.times do
     transactiontype = Faker::Number.within(range: 0..1)
-    paymenttype = Faker::Number.within(range:0..3)
+    paymenttype = Faker::Number.within(range:0..1)
     status = Faker::Number.within(range:0..2)
     if transactiontype == 1 && status == 0
       participants = Participant.where(member:member).where.not(activity:[nil,1]).select{|p| p.currency != nil}.sample(Faker::Number.within(range:1..6))

--- a/db/seeds/payments.rb
+++ b/db/seeds/payments.rb
@@ -7,7 +7,8 @@ Member.all.sample(30).each do |member|
 
   15.times do
     transactiontype = Faker::Number.within(range: 0..1)
-    paymenttype = Faker::Number.within(range:0..1)
+    # either ideal or pin (see app/models/payment.rb)
+    paymenttype = Faker::Number.within(range: 0.0..1.0) < 0.5 ? 0 : 3
     status = Faker::Number.within(range:0..2)
     if transactiontype == 1 && status == 0
       participants = Participant.where(member:member).where.not(activity:[nil,1]).select{|p| p.currency != nil}.sample(Faker::Number.within(range:1..6))
@@ -18,7 +19,7 @@ Member.all.sample(30).each do |member|
       status = 2
     else
       transaction_id = [1]
-      status = 0 
+      status = 0
     end
     description = transactiontype == 0 ? "Mongoose Opwaardering" : "Activiteiten - #{transaction_id}"
 

--- a/doc/webhook_readme.md
+++ b/doc/webhook_readme.md
@@ -1,6 +1,6 @@
 
 ## Webhook setup
-When you want to test Mollie or Payconiq while developing there are certain webhooks that need to be available to public networks.  For this we use ngrok to tunnel our local network securly to the internet. Here is a small guide on how to set this up.
+When you want to test Mollie while developing there are certain webhooks that need to be available to public networks.  For this we use ngrok to tunnel our local network securly to the internet. Here is a small guide on how to set this up.
 
 1. install ngrok [Here](https://ngrok.com/download).
 2. Run this command ``ngrok http -host-header=koala.rails.local koala.rails.local:3000``
@@ -24,6 +24,6 @@ HTTP Requests
 -------------      
 ```
 4. Copy the first "Forwarding" ngrok link (in this case http://bf68e1ab4469.ngrok.io) and paste it in your `.env` at the var NGROK_HOST.
-5. Restart koala and you should be able to test Payconiq & Mollie
+5. Restart koala and you should be able to test Mollie
 
 

--- a/sample.env
+++ b/sample.env
@@ -78,12 +78,6 @@ NGROK_HOST=http
 # Hostname of where Koala is running, like https://koala.svsticky.nl or http://koala.rails.local:3000
 KOALA_DOMAIN=
 
-# PAYCONIQ credentials
-PAYCONIQ_DOMAIN=https://api.ext.payconiq.com
-PAYCONIQ_VERSION=v3
-PAYCONIQ_ONLINE_TOKEN=
-PAYCONIQ_DISPLAY_TOKEN=
-
 # MOLLIE credentials for the iDEAL integration.
 MOLLIE_DOMAIN=https://api.mollie.nl
 MOLLIE_VERSION=v1


### PR DESCRIPTION
Resolves #900,

This removes all references to Payconiq in the codebase (where possible)
This also removes the dropdowns that once showed the choice between Ideal and Payconiq, but are now useless.
This should be tested thoroughly on staging, as test payments cannot go through in development (due to the return address not being reachable by the payment provider).