### PR TITLE
Checkmark consistency and overrides for enrollable date

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -193,18 +193,18 @@ class Activity < ApplicationRecord
   end
 
   def open?
-    return is_enrollable && ((not open_present?) || DateTime.now > when_open)
+    return is_enrollable && (!open_present? || DateTime.now > when_open)
   end
 
-  #used for the is_enrollable checkmark
+  # used for the is_enrollable checkmark
   def validate_enrollable
-    if open_present? && DateTime.now < when_open #activity has open date, but is has not opened yet
-      if self.is_enrollable #we want to open the activity anyway (override)
-        self.open_date = nil
-        self.open_time = nil
-      else #open? will give the checkmark a value of false, but we want is_enrollable to stay true as long as there is an open date pending
-        self.is_enrollable = true
-      end
+    return unless open_present? && DateTime.now < when_open # activity does not have open date or is already opened
+
+    if is_enrollable # we want to open the activity anyway (override)
+      self.open_date = nil
+      self.open_time = nil
+    else # open? will give the checkmark a value of false, but we want is_enrollable to stay true as long as there is an open date pending
+      self.is_enrollable = true
     end
   end
 

--- a/app/views/admin/activities/partials/_edit.html.haml
+++ b/app/views/admin/activities/partials/_edit.html.haml
@@ -153,7 +153,7 @@
 
         .row
           .col-md-4
-            = f.check_box :is_enrollable, checked: @activity.is_enrollable, disabled: !@activity.is_viewable, data: {original: @activity.is_enrollable}
+            = f.check_box :is_enrollable, checked: @activity.open?, disabled: !@activity.is_viewable, data: {original: @activity.open?}
             = f.label :is_enrollable
           .col-md-4
             = f.check_box :is_alcoholic, checked: @activity.is_alcoholic


### PR DESCRIPTION
The "is_enrollable" checkmark now gets automatically checked when an activity opens. This checkmark can then be unchecked to close the activity again. Checking the "is_enrollable" checkmark before the activity is opened, will remove the open date and time and open up the activity.

Creating an activity with both an open date and time and the "is_enrollable" checkmark will also remove the open date and time and open the activity for enrollement. Perhaps an error should be given to warn the creator instead?