### PR TITLE
Fix #939

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -91,7 +91,7 @@ class Admin::MembersController < ApplicationController
     @member = Member.find(params[:member_id])
 
     MailchimpUpdateAddressJob.perform_later @member.email, @member.user.unconfirmed_email, member_post_params[:mailchimp_interests].reject(&:blank?) unless
-      ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?
+      @member.mailchimp_interests.nil? || ENV['MAILCHIMP_DATACENTER'].blank?
 
     Mailings::Devise.forced_confirm_email(@member, current_user).deliver_later
     @member.user.force_confirm_email!


### PR DESCRIPTION
There are no params in a patch, we should check member attributes instead.
Also reversed the order so this is more testable (Mailchimp is not available in staging / CI)