### PR TITLE
activity edit: check if start_time is present before reading its value

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -214,7 +214,8 @@ class Activity < ApplicationRecord
     errors.add(:start_time, :blank_and_end_time) if start_time.nil? &&
                                                     end_time.present?
 
-    errors.add(:end_time, :before_start_time) if end_time.present? &&
+    errors.add(:end_time, :before_start_time) if start_time.present? &&
+                                                 end_time.present? &&
                                                  end_date == start_date &&
                                                  end_time < start_time
   end

--- a/app/views/admin/activities/partials/_edit.html.haml
+++ b/app/views/admin/activities/partials/_edit.html.haml
@@ -83,7 +83,7 @@
             = f.date_field :start_date, :value => @activity.start_date, :class => 'form-control'
           .col-md-6
             = label(:activity, :start_time)
-            = f.time_field :start_time, :value => (I18n.l(@activity.start_time, :format => :short) unless @activity.end_time.nil?), :class => 'form-control'
+            = f.time_field :start_time, :value => (I18n.l(@activity.start_time, :format => :short) unless @activity.start_time.nil?), :class => 'form-control'
       .form-group
         .row
           .col-md-6


### PR DESCRIPTION
This should fix issue #940 by checking if the start_time is present before reading its value.
While debugging the issue I came across a related issue that also has been fixed.