### PR TITLE
fix missing translation for payconiq_online

### DIFF
--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -157,6 +157,7 @@ en:
       member: Member
       payment_type:
         ideal: Ideal
+        payconiq_online: PayConiq
         pin: Pinned
         title: Payment Method
       state:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -157,6 +157,7 @@ nl:
       member: Lid
       payment_type:
         ideal: Ideal
+        payconiq_online: PayConiq
         pin: Gepind
         title: Betaalmethode
       state:


### PR DESCRIPTION
This translations were removed in #907, but are still shown on the transactions page.
This is still needed as long as there are Payconiq transactions in the database (which is required by Dutch law for 7 years)