### PR TITLE
Fix incorrectly formatted time on board posts

### DIFF
--- a/app/views/members/home/index.html.haml
+++ b/app/views/members/home/index.html.haml
@@ -18,7 +18,7 @@
                 = image_tag post.author.avatar_representation, class: 'avatar'
               %h4= post.author.name
               %ul
-                %li= I18n.l(post.published_at, format: "%H:%m - %d %B %Y")
+                %li= I18n.l(post.published_at, format: "%H:%M - %d %B %Y")
                 - post.tags&.each do |tag|
                   %li= tag
           .card-body.content


### PR DESCRIPTION
Fixes #959
I though I fixed this already in #962, but apparently the bug was also present at the members side.
