### PR TITLE
prevent the CI from running twice on a PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: "Build & Test"
-on: [push, pull_request]
+on:
+  - push
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently the CI is instructed to run both on a push and a pull request, which leads to double runs.
This PR prevents that.