### PR TITLE
make it possible to unenroll after the deadline for reservists

### DIFF
--- a/app/javascript/src/members/activities/activities.js
+++ b/app/javascript/src/members/activities/activities.js
@@ -95,7 +95,7 @@ function confirm_un_enroll_date_passed(activity) {
 }
 
 function confirm_un_enroll(activity) {
-  if (activity.has_un_enroll_date_passed()) {
+  if (activity.has_un_enroll_date_passed() && !activity.is_reservist()) {
     Swal.fire(
       I18n.t("members.activities.error.unenroll_failed"),
       I18n.t("members.activities.error.unenroll_deadline"),

--- a/app/javascript/src/members/activities/activity.js
+++ b/app/javascript/src/members/activities/activity.js
@@ -130,6 +130,13 @@ export class Activity {
   is_last() {
     return typeof this.next_activity === "undefined";
   }
+
+  /**
+   * Returns whether the current participant is a reservist.
+   */
+  is_reservist() {
+    return this._enrollment_status == Enrollment_stati.reservist;
+  }
 }
 
 Activity.full_string = I18n.t("members.activities.full");


### PR DESCRIPTION
Fixes #964 

This makes it possible for a reservist to unroll from the spares list, even after the unenroll deadline has passed.
This lets the member signal that they don't want to come to this activity, even if extra spaces are available.