### PR TITLE
add Stickypedia to the members sidebar

### DIFF
--- a/app/views/layouts/members.html.haml
+++ b/app/views/layouts/members.html.haml
@@ -84,6 +84,9 @@
               = link_to "https://svsticky.nl/discord/", :class => 'list-group-item list-group-item-action' do
                 %span= I18n.t('members.navigation.discord')
                 %i.fab.fa-discord
+              = link_to "https://wiki.svsticky.nl/", :class => 'list-group-item list-group-item-action' do
+                %span= I18n.t('members.navigation.wiki')
+                %i.fa.fa-info-circle
             -# Signout button for mobile
             = link_to destroy_user_session_path, 'data-method' => :delete, :class => 'list-group-item list-group-item-action d-md-none' do
               %span= I18n.t('devise.sessions.new.sign_out')

--- a/config/locales/members.en.yml
+++ b/config/locales/members.en.yml
@@ -93,6 +93,7 @@ en:
       payments: Payments
       pictures: Pictures
       vacancies: Vacancies
+      wiki: Stickypedia
     payments:
       mongoose:
         credit: Credit

--- a/config/locales/members.nl.yml
+++ b/config/locales/members.nl.yml
@@ -93,6 +93,7 @@ nl:
       payments: Betalingen
       pictures: Foto's
       vacancies: Vacatures
+      wiki: Stickypedia
     payments:
       mongoose:
         credit: Tegoed


### PR DESCRIPTION
Fixes #963

This adds a link to Stickypedia to the members sidebar