### PR TITLE
limit export of translations with i18n to actually used ones

### DIFF
--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -11,5 +11,7 @@ translations:
     prefix: "import I18n from 'i18n-js';\n"
     suffix: "export default I18n;\n"
     only:
-      - "en"
-      - "nl"
+      - "*.admin"
+      - "*.checkout"
+      - "*.mailings"
+      - "*.members"


### PR DESCRIPTION
fixes #955 

This instructs `i18n-js` to limit the exported translations to the keys we actually use in javascript.
This doesn't prevent exporting some translations we don't use, but at least limits the size of the file with a factor 50 (1.6M to 34K)