### PR TITLE
update payment email and whatsapp text

### DIFF
--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -120,7 +120,7 @@ en:
         copy: Message copied to clipboard
         copy_error: Message could not be retrieved
         open_activities: You still have not paid for the following activities
-        pay_to: Could you transfer this amount to *NL61INGB0002877106* citing _Outstanding %{member}_?
+        pay_to: Please pay this as soon as possible via the payment portal (https://koala.svsticky.nl/member/payments)
         title: Hey! %{user} from Sticky here :)
         total_of: This comes down to a total of *%{amount}*
     posts:

--- a/config/locales/admin.nl.yml
+++ b/config/locales/admin.nl.yml
@@ -120,7 +120,7 @@ nl:
         copy: Bericht gekopieerd naar klembord
         copy_error: Bericht kon niet worden opgehaald
         open_activities: De volgende activiteiten staan open
-        pay_to: Kan je dit overmaken naar *NL61INGB0002877106* onder vermelding van _Openstaand %{member}_?
+        pay_to: 'Zou je dit bedrag zo snel mogelijk via het betalingsportaal op Koala willen betalen? Deze kun je vinden via de volgende link: https://koala.svsticky.nl/member/payments'
         title: Hey! %{user} van Sticky hier :)
         total_of: Dit geeft een totaal van *%{amount}*
     posts:

--- a/config/locales/mailings.en.yml
+++ b/config/locales/mailings.en.yml
@@ -62,7 +62,7 @@ en:
       inform:
         activity_payable_unvisited_html: You are going to visit <strong>%{subject}</strong>, this activity costs %recipient.price%.
         activity_visited_html: You visited <strong>%{subject}</strong>, this activity cost %recipient.price%.
-        payment_instructions_html: Please transfer this amount to NL61INGB0002877106 t.n.v. Study association Sticky citing <i>"%{subject} %recipient.name%"</i>?
+        payment_instructions_html: Please pay this as soon as possible via the <a href="https://koala.svsticky.nl/member/payments">payment portal</a>
     removed: is immediatly removed
     sent:
       'false': Mail has not been sent!

--- a/config/locales/mailings.nl.yml
+++ b/config/locales/mailings.nl.yml
@@ -62,7 +62,7 @@ nl:
       inform:
         activity_payable_unvisited_html: Je gaat mee naar <strong>%{subject}</strong>, deze activiteit kost %recipient.price%.
         activity_visited_html: Je bent meegeweest naar <strong>%{subject}</strong>, deze activiteit kostte %recipient.price%.
-        payment_instructions_html: Zou je dit bedrag zo snel mogelijk willen overmaken naar NL61INGB0002877106 t.n.v. Studievereniging Sticky o.v.v. <i>"%{subject} - %recipient.name%"</i>?
+        payment_instructions_html: Zou je dit bedrag zo snel mogelijk via het <a href="https://koala.svsticky.nl/member/payments>betalingsportaal op Koala</a> willen betalen?
     removed: is direct verwijderd
     sent:
       'false': Mail is niet verstuurd!


### PR DESCRIPTION
Fixes #929

This updates the payment email and whatsapp text to inform the user of the payment portal.
The exact text is a bit different from the issue, as in email we can use html <a> tags instead of full urls.