### PR TITLE
fix some rubocop-rails todo's

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,19 +26,6 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 27
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: NilOrEmpty, NotPresent, UnlessPresent.
-Rails/Blank:
-  Exclude:
-    - 'app/models/payment.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct-all.
-Rails/CompactBlank:
-  Exclude:
-    - 'app/controllers/admin/members_controller.rb'
-
 # Offense count: 32
 # Configuration parameters: EnforcedStyle, AllowToTime.
 # SupportedStyles: strict, flexible
@@ -59,15 +46,6 @@ Rails/Date:
     - 'app/models/member.rb'
     - 'lib/tasks/admin.rake'
     - 'test/models/member_test.rb'
-
-# Offense count: 54
-# Cop supports --auto-correct-all.
-# Configuration parameters: Whitelist, AllowedMethods, AllowedReceivers.
-# Whitelist: find_by_sql
-# AllowedMethods: find_by_sql
-# AllowedReceivers: Gem::Specification
-Rails/DynamicFindBy:
-  Enabled: false
 
 # Offense count: 4
 # Configuration parameters: Include.
@@ -105,17 +83,6 @@ Rails/MailerName:
 Rails/MatchRoute:
   Exclude:
     - 'config/routes.rb'
-
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: Include.
-# Include: app/**/*.rb, config/**/*.rb, db/**/*.rb, lib/**/*.rb
-Rails/Output:
-  Exclude:
-    - 'app/controllers/admin/participants_controller.rb'
-    - 'app/mailers/mailings/checkout.rb'
-    - 'app/mailers/mailings/devise.rb'
-    - 'app/models/member.rb'
 
 # Offense count: 3
 # Cop supports --auto-correct.

--- a/app/controllers/admin/group_members_controller.rb
+++ b/app/controllers/admin/group_members_controller.rb
@@ -1,7 +1,7 @@
 #:nodoc:
 class Admin::GroupMembersController < ApplicationController
   def create
-    @member = GroupMember.new(member: Member.find_by_id(params[:member]), group: Group.find_by_id(params[:group_id]), year: params[:year])
+    @member = GroupMember.new(member: Member.find_by(id: params[:member]), group: Group.find_by(id: params[:group_id]), year: params[:year])
 
     head :bad_request unless @member.save
 
@@ -10,7 +10,7 @@ class Admin::GroupMembersController < ApplicationController
   end
 
   def update
-    @member = GroupMember.find_by_id(params[:id])
+    @member = GroupMember.find_by(id: params[:id])
 
     head :bad_request unless @member.update(position: params[:position])
 

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -10,7 +10,7 @@ class Admin::GroupsController < ApplicationController
 
   def show
     @groups = Group.all.order(:category, :name)
-    @group = Group.find_by_id params[:id]
+    @group = Group.find_by id: params[:id]
   end
 
   def create
@@ -26,7 +26,7 @@ class Admin::GroupsController < ApplicationController
   end
 
   def update
-    @group = Group.find_by_id params[:id]
+    @group = Group.find_by id: params[:id]
 
     if @group.update(group_params)
       impressionist @group

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -35,7 +35,7 @@ class Admin::MembersController < ApplicationController
 
     @pagination, @transactions = pagy(CheckoutTransaction
       .where(checkout_balance: CheckoutBalance
-      .find_by_member_id(params[:id]))
+      .find_by(member_id: params[:id]))
       .order(created_at: :desc), items: 10)
   end
 
@@ -50,7 +50,7 @@ class Admin::MembersController < ApplicationController
     @member = Member.new member_post_params.except 'mailchimp_interests'
 
     if @member.save
-      MailchimpJob.perform_later @member.email, @member, member_post_params[:mailchimp_interests].reject(&:blank?) unless
+      MailchimpJob.perform_later @member.email, @member, member_post_params[:mailchimp_interests].compact_blank unless
         ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?
 
       @member.tags_names = params[:member][:tags_names]
@@ -78,7 +78,7 @@ class Admin::MembersController < ApplicationController
 
     if @member.update member_post_params.except 'mailchimp_interests'
 
-      MailchimpJob.perform_later @member.email, @member, member_post_params[:mailchimp_interests].reject(&:blank?) unless
+      MailchimpJob.perform_later @member.email, @member, member_post_params[:mailchimp_interests].compact_blank unless
         ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?
 
       impressionist @member

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -2,8 +2,8 @@
 class Admin::ParticipantsController < ApplicationController
   def create
     @participant = Participant.new(
-      member: Member.find_by_id(params[:member]),
-      activity: Activity.find_by_id(params[:activity_id])
+      member: Member.find_by(id: params[:member]),
+      activity: Activity.find_by(id: params[:activity_id])
     )
 
     impressionist(@participant) if @participant.save
@@ -11,7 +11,6 @@ class Admin::ParticipantsController < ApplicationController
 
   def update
     @participant = Participant.find(params[:id])
-    puts @participant
 
     if params[:reservist].present?
       message = params[:reservist].to_b ? 'reservist' : 'participant'

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -18,12 +18,12 @@ class Admin::PostsController < ApplicationController
 
   def show
     @pagination, @posts = pagination_posts
-    @post = Post.find_by_id params[:id]
+    @post = Post.find_by id: params[:id]
     render 'index'
   end
 
   def update
-    @post = Post.find_by_id params[:id]
+    @post = Post.find_by id: params[:id]
     @post.update(post_params)
     @pagination, @posts = pagination_posts
     render 'index'

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -4,7 +4,7 @@ class Admin::SettingsController < ApplicationController
 
   def index
     @admin = current_user.credentials
-    @user = User.find_by_email(current_user.email)
+    @user = User.find_by(email: current_user.email)
 
     @studies = Study.all
 
@@ -47,7 +47,7 @@ class Admin::SettingsController < ApplicationController
   end
 
   def profile
-    @user = User.find_by_email(current_user.email)
+    @user = User.find_by(email: current_user.email)
     @user.update(user_post_params)
 
     @admin = Admin.find(current_user.credentials_id)

--- a/app/controllers/api/checkout_controller.rb
+++ b/app/controllers/api/checkout_controller.rb
@@ -13,7 +13,7 @@ class Api::CheckoutController < ActionController::Base
 
   def recent
     recent = CheckoutTransaction.joins(:checkout_card).where(
-      checkout_card: CheckoutCard.where(member_id: CheckoutCard.find_by_uuid(params[:uuid]).member_id)
+      checkout_card: CheckoutCard.where(member_id: CheckoutCard.find_by(uuid: params[:uuid]).member_id)
     ).order(created_at: :desc).limit(5)
     items = []
     recent.each do |item|
@@ -32,7 +32,7 @@ class Api::CheckoutController < ActionController::Base
   end
 
   def purchase
-    card = CheckoutCard.find_by_uuid!(params[:uuid])
+    card = CheckoutCard.find_by!(uuid: params[:uuid])
 
     transaction = CheckoutTransaction.new(items: ahelper(params[:items]), checkout_card: card)
 
@@ -70,13 +70,13 @@ class Api::CheckoutController < ActionController::Base
   end
 
   def create
-    head(:conflict) && return unless CheckoutCard.find_by_uuid(params[:uuid]).nil?
+    head(:conflict) && return unless CheckoutCard.find_by(uuid: params[:uuid]).nil?
 
-    card = CheckoutCard.new(uuid: params[:uuid], member: Member.find_by_student_id!(params[:student]), description: params[:description])
+    card = CheckoutCard.new(uuid: params[:uuid], member: Member.find_by!(student_id: params[:student]), description: params[:description])
 
     if card.save
       card.send_confirmation!
-      render status: :created, json: CheckoutCard.joins(:member, :checkout_balance).select(:id, :uuid, :first_name, :balance).find_by_uuid!(params[:uuid]).to_json
+      render status: :created, json: CheckoutCard.joins(:member, :checkout_balance).select(:id, :uuid, :first_name, :balance).find_by!(uuid: params[:uuid]).to_json
     else
       head :conflict
     end

--- a/app/controllers/api/internal_controller.rb
+++ b/app/controllers/api/internal_controller.rb
@@ -6,7 +6,7 @@ class Api::InternalController < ActionController::Base
   respond_to :json
 
   def member_by_studentid
-    @mongoose_user = Member.select(:id, :first_name, :infix, :last_name, :birth_date, :email).find_by_student_id(params[:student_number])
+    @mongoose_user = Member.select(:id, :first_name, :infix, :last_name, :birth_date, :email).find_by(student_id: params[:student_number])
     return head :no_content unless @mongoose_user
   end
 

--- a/app/controllers/api/participants_controller.rb
+++ b/app/controllers/api/participants_controller.rb
@@ -5,7 +5,7 @@ class Api::ParticipantsController < ApiController
 
   def index
     if params[:activity_id].present?
-      @participants = Participant.where(activity: Activity.find_by_id(params[:activity_id])).includes(:activity, :member)
+      @participants = Participant.where(activity: Activity.find_by(id: params[:activity_id])).includes(:activity, :member)
 
     elsif params[:member_id].present?
       head(:unauthorized) && return unless Authorization._member.id == params[:member_id].to_i
@@ -31,7 +31,7 @@ class Api::ParticipantsController < ApiController
 
   # TODO: uitschrijfdeadline hierin meenemen
   def destroy
-    participant = Participant.find_by_member_id_and_activity_id! Authorization._member.id, params[:activity_id]
+    participant = Participant.find_by! member_id: Authorization._member.id, activity_id: params[:activity_id]
 
     head(:locked) && return if participant.paid
     head(:locked) && return if participant.activity.start_date <= Date.today

--- a/app/controllers/api/webhook_controller.rb
+++ b/app/controllers/api/webhook_controller.rb
@@ -1,7 +1,7 @@
 #:nodoc:
 class Api::WebhookController < ApiController
   def payment_redirect
-    transaction = Payment.find_by_token!(params[:token])
+    transaction = Payment.find_by!(token: params[:token])
     transaction.finalize! if transaction.update_transaction!
 
     flash[:notice] = transaction.message if transaction.successful? || transaction.in_progress?
@@ -14,7 +14,7 @@ class Api::WebhookController < ApiController
   end
 
   def mollie_hook
-    transaction = Payment.find_by_trxid!(params[:id])
+    transaction = Payment.find_by!(trxid: params[:id])
     transaction.finalize! if transaction.update_transaction!
 
     head :ok
@@ -33,7 +33,7 @@ class Api::WebhookController < ApiController
     head(:precondition_failed) && return unless params[:data][:list_id] == ENV['MAILCHIMP_LIST_ID']
     head(:method_not_allowed) && return unless ['subscribe', 'unsubscribe', 'profile', 'cleaned'].include? params[:type]
 
-    member = Member.find_by_email! params[:data][:email]
+    member = Member.find_by! email: params[:data][:email]
 
     Rails.cache.delete("members/#{ member.id }/mailchimp/interests")
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,8 +4,8 @@ class ApiController < ActionController::Base
 
   around_action do |_, action|
     # NOTE: Authorization is set so that the session can be seen in the rabl views, the variable is set in one thread and cleared after the work is done
-    Authorization._user = User.find_by_id(doorkeeper_token.resource_owner_id) if doorkeeper_token
-    Authorization._client = Doorkeeper::Application.find_by_id(doorkeeper_token.application_id) if doorkeeper_token
+    Authorization._user = User.find_by(id: doorkeeper_token.resource_owner_id) if doorkeeper_token
+    Authorization._client = Doorkeeper::Application.find_by(id: doorkeeper_token.application_id) if doorkeeper_token
 
     action.call
   ensure

--- a/app/controllers/members/activities_controller.rb
+++ b/app/controllers/members/activities_controller.rb
@@ -30,7 +30,7 @@ class Members::ActivitiesController < ApplicationController
   # field.
   def show
     @member = Member.find(current_user.credentials_id)
-    @user = Member.find_by_email(current_user.email)
+    @user = Member.find_by(email: current_user.email)
     @activity = Activity.find(params[:id])
 
     # Don't allow activities for old activities

--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -9,7 +9,7 @@ class Members::HomeController < ApplicationController
     @member = Member.find(current_user.credentials_id)
 
     # information of the middlebar
-    @balance = CheckoutBalance.find_by_member_id(current_user.credentials_id)
+    @balance = CheckoutBalance.find_by(member_id: current_user.credentials_id)
     @debt = Participant
             .where(paid: false, member: @member, reservist: false)
             .joins(:activity)
@@ -33,13 +33,13 @@ class Members::HomeController < ApplicationController
              .where(participants: { member: @member, reservist: false })
              .order('start_date DESC')
 
-    @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by_member_id(current_user.credentials_id)).order(created_at: :desc).limit(10) # ParticipantTransaction.all #
+    @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by(member_id: current_user.credentials_id)).order(created_at: :desc).limit(10) # ParticipantTransaction.all #
     @transaction_costs = Settings.mongoose_ideal_costs
   end
 
   def edit
     @member = Member.includes(:educations).includes(:tags).find(current_user.credentials_id)
-    @user = User.find_by_email(current_user.email)
+    @user = User.find_by(email: current_user.email)
     @applications = [] # TODO: Doorkeeper::Application.authorized_for(current_user)
 
     @member.educations.build(id: '-1') if @member.educations.empty?
@@ -51,7 +51,7 @@ class Members::HomeController < ApplicationController
   end
 
   def update
-    @user = User.find_by_email(current_user.email)
+    @user = User.find_by(email: current_user.email)
     @user.update(user_post_params)
 
     @member = Member.find(current_user.credentials_id)
@@ -76,7 +76,7 @@ class Members::HomeController < ApplicationController
 
   def download
     @member = Member.includes(:activities, :groups, :educations).find(current_user.credentials_id)
-    @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by_member_id(current_user.credentials_id)).order(created_at: :desc)
+    @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by(member_id: current_user.credentials_id)).order(created_at: :desc)
 
     send_data render_to_string(layout: false),
               filename: "#{ @member.name.downcase.tr(' ', '-') }.html",

--- a/app/controllers/members/payments_controller.rb
+++ b/app/controllers/members/payments_controller.rb
@@ -7,7 +7,7 @@ class Members::PaymentsController < ApplicationController
   def index
     @member = Member.find(current_user.credentials_id)
     @participants = @member.unpaid_activities
-    @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by_member_id(current_user.credentials_id)).order(created_at: :desc).limit(10) # ParticipantTransaction.all #
+    @transactions = CheckoutTransaction.where(checkout_balance: CheckoutBalance.find_by(member_id: current_user.credentials_id)).order(created_at: :desc).limit(10) # ParticipantTransaction.all #
     @transaction_costs = Settings.mongoose_ideal_costs
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ class Users::RegistrationsController < ActionController::Base
     end
 
     @user = User.new sign_up_params
-    @user.credentials = Member.find_by_email sign_up_params[:email]
+    @user.credentials = Member.find_by email: sign_up_params[:email]
 
     flash[:alert] = nil
 

--- a/app/mailers/mailings/checkout.rb
+++ b/app/mailers/mailings/checkout.rb
@@ -3,7 +3,7 @@ module Mailings
   #:nodoc:
   class Checkout < ApplicationMailer
     def confirmation_instructions(card, confirmation_url)
-      puts confirmation_url if Rails.env.development?
+      Rails.logger.debug confirmation_url if Rails.env.development?
       return if ENV['MAILGUN_TOKEN'].blank?
 
       subject_name = "#{ I18n.t('association_name') } | #{ I18n.t('mailings.checkout.subject') }"

--- a/app/mailers/mailings/devise.rb
+++ b/app/mailers/mailings/devise.rb
@@ -5,7 +5,7 @@ module Mailings
     include ::Devise::Controllers::UrlHelpers
 
     def confirmation_instructions(record, token, _opts = {})
-      puts confirmation_url(record, confirmation_token: token) if Rails.env.development?
+      Rails.logger.debug confirmation_url(record, confirmation_token: token) if Rails.env.development?
       return if ENV['MAILGUN_TOKEN'].blank?
 
       html = render_to_string locals: {
@@ -29,7 +29,7 @@ module Mailings
 
     def activation_instructions(record, token, _opts = {})
       url = new_member_confirmation_url(confirmation_token: token)
-      puts url if Rails.env.development?
+      Rails.logger.debug url if Rails.env.development?
       return if ENV['MAILGUN_TOKEN'].blank?
 
       html = render_to_string locals: {
@@ -80,7 +80,7 @@ module Mailings
     end
 
     def reset_password_instructions(record, token, _opts = {})
-      puts edit_password_url(record, reset_password_token: token) if Rails.env.development?
+      Rails.logger.debug edit_password_url(record, reset_password_token: token) if Rails.env.development?
       return if ENV['MAILGUN_TOKEN'].blank?
 
       html = render_to_string locals: {
@@ -104,7 +104,7 @@ module Mailings
     end
 
     def forced_confirm_email(record, current_user, _opts = {})
-      puts "#{ record.user.unconfirmed_email } #{ I18n.t('mailings.removed') }" if Rails.env.development?
+      Rails.logger.debug { "#{ record.user.unconfirmed_email } #{ I18n.t('mailings.removed') }" } if Rails.env.development?
       return if ENV['MAILGUN_TOKEN'].blank?
 
       html = render_to_string locals: {

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -132,7 +132,7 @@ class Activity < ApplicationRecord
   end
 
   def group
-    Group.find_by_id organized_by
+    Group.find_by id: organized_by
   end
 
   def currency(member)

--- a/app/models/checkout_product.rb
+++ b/app/models/checkout_product.rb
@@ -40,11 +40,11 @@ class CheckoutProduct < ApplicationRecord
 
     return nil if parent.nil?
 
-    return CheckoutProduct.find_by_id(parent).url
+    return CheckoutProduct.find_by(id: parent).url
   end
 
   def children?
-    return true unless CheckoutProduct.find_by_parent(id).nil?
+    return true unless CheckoutProduct.find_by(parent: id).nil?
 
     return false
   end
@@ -52,7 +52,7 @@ class CheckoutProduct < ApplicationRecord
   def parents
     return [] if parent.nil?
 
-    return CheckoutProduct.where(id: parent).select(:id, :name, :price, :category, :created_at) + CheckoutProduct.find_by_id(parent).parents
+    return CheckoutProduct.where(id: parent).select(:id, :name, :price, :category, :created_at) + CheckoutProduct.find_by(id: parent).parents
   end
 
   def sales(year = nil)
@@ -64,7 +64,7 @@ class CheckoutProduct < ApplicationRecord
 
     return [{ self => count }] if parent.nil?
 
-    return [{ self => count }] + CheckoutProduct.find_by_id(parent).sales(year)
+    return [{ self => count }] + CheckoutProduct.find_by(id: parent).sales(year)
   end
 
   def self.last_version

--- a/app/models/checkout_transaction.rb
+++ b/app/models/checkout_transaction.rb
@@ -57,8 +57,8 @@ class CheckoutTransaction < ApplicationRecord
 
     counts = {}
     items.each do |item|
-      counts[CheckoutProduct.find_by_id(item).name] = 0 unless counts.key?(CheckoutProduct.find_by_id(item).name)
-      counts[CheckoutProduct.find_by_id(item).name] += 1
+      counts[CheckoutProduct.find_by(id: item).name] = 0 unless counts.key?(CheckoutProduct.find_by(id: item).name)
+      counts[CheckoutProduct.find_by(id: item).name] += 1
     end
 
     strings = counts.map do |item, count|

--- a/app/models/education.rb
+++ b/app/models/education.rb
@@ -13,7 +13,7 @@ class Education < ApplicationRecord
   enum status: { active: 0, stopped: 1, graduated: 2, inactive: 3 }
 
   def self.find_by_year_and_study_code(year, code)
-    study = Study.find_by_code(code)
+    study = Study.find_by(code: code)
     return where('extract(year from start_date) = ? AND study_id = ?', year, study.id).first
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -147,7 +147,7 @@ class Member < ApplicationRecord
     tags.each do |tag|
       next if tag.empty?
 
-      puts Tag.where(member_id: id, name: Tag.names[tag]).first_or_create!
+      Tag.where(member_id: id, name: Tag.names[tag]).first_or_create!
     end
   end
 
@@ -256,12 +256,12 @@ class Member < ApplicationRecord
     unless study.nil?
       query.gsub!(/(studie|study):([A-Za-z-]+)/, '')
 
-      code = Study.find_by_code(study[2])
+      code = Study.find_by(code: study[2])
 
       # Lookup using full names
       if code.nil?
         study_name = Study.all.map { |s| { I18n.t(s.code.downcase, scope: 'activerecord.attributes.study.names').downcase => s.code.downcase } }.find { |hash| hash.keys[0] == study[2].downcase.tr('-', ' ') }
-        code = Study.find_by_code(study_name.values[0]) unless study_name.nil?
+        code = Study.find_by(code: study_name.values[0]) unless study_name.nil?
       end
 
       records = Member.none if code.nil? # TODO: add active to the selector if status is not in the query

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -125,7 +125,7 @@ class Payment < ApplicationRecord
 
       # create a single transaction to update the checkoutbalance and mark the Payment as processed
       Payment.transaction do
-        transaction = CheckoutTransaction.create!(price: (amount - transaction_fee), checkout_balance: CheckoutBalance.find_by_member_id!(member), payment_method: payment_type)
+        transaction = CheckoutTransaction.create!(price: (amount - transaction_fee), checkout_balance: CheckoutBalance.find_by!(member_id: member), payment_method: payment_type)
 
         self.transaction_id = [transaction.id]
         save!
@@ -148,7 +148,7 @@ class Payment < ApplicationRecord
 
   def self.ideal_issuers
     # cache the payment issuers for 12 hours, don't request it to often. Stored in tmp/cache
-    return [] unless ENV['MOLLIE_TOKEN'].present?
+    return [] if ENV['MOLLIE_TOKEN'].blank?
 
     Rails.cache.fetch('mollie_issuers', expires_in: 12.hours) do
       http = ConstipatedKoala::Request.new ENV['MOLLIE_DOMAIN']

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -94,20 +94,20 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "8c08dc71a8af936322aef7b0bb64fade45df68eaa90f7a0b077ed739749e8f00",
+      "fingerprint": "cdbd2ad3a4f8f2282f40f239c4213bb9dced1eaca9c2da15f5a553bcdee85171",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/api/webhook_controller.rb",
       "line": 13,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Payment.find_by_token!(params[:token]).redirect_uri)",
+      "code": "redirect_to(Payment.find_by!(:token => params[:token]).redirect_uri)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Api::WebhookController",
         "method": "payment_redirect"
       },
-      "user_input": "Payment.find_by_token!(params[:token]).redirect_uri",
+      "user_input": "Payment.find_by!(:token => params[:token]).redirect_uri",
       "confidence": "High",
       "note": "Needed for processing payments"
     },
@@ -138,7 +138,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/admin/participants_controller.rb",
-      "line": 52,
+      "line": 51,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params[:recipients].permit!",
       "render_path": null,
@@ -203,6 +203,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-04-20 12:28:27 +0200",
+  "updated": "2022-04-21 22:14:12 +0200",
   "brakeman_version": "5.2.1"
 }

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -16,7 +16,7 @@ namespace :admin do
 
   desc 'Delete a normal user, that is it\'s login access'
   task :remove, [:email] => :environment do |_, args|
-    user = User.find_by_email args[:email]
+    user = User.find_by email: args[:email]
 
     if user.nil?
       puts "#{ args[:email] } not found"
@@ -31,7 +31,7 @@ namespace :admin do
 
   desc 'Delete an admin account and user'
   task :delete, [:email] => :environment do |_, args|
-    user = User.find_by_email args[:email]
+    user = User.find_by email: args[:email]
 
     if user.nil? || !user.admin?
       puts "#{ args[:email] } not found"

--- a/lib/tasks/doorkeeper.rake
+++ b/lib/tasks/doorkeeper.rake
@@ -21,7 +21,7 @@ namespace :doorkeeper do
 
   desc 'Delete an application using the application id.'
   task :delete, [:application] => :environment do |_, args|
-    app = Doorkeeper::Application.find_by_uid! args[:application]
+    app = Doorkeeper::Application.find_by! uid: args[:application]
     app.destroy
   end
 end


### PR DESCRIPTION
This fixes some rubocop-rails todo's.
The most important of those is that we enable the `DynamicFindBy` cop.
This cop disallows the use of the confusing dynamic `find_by_x` method, in favor for the clearer `find_by x:`.