### PR TITLE
admin/member creation: remove superfluous and undefined NIL parameter

### DIFF
--- a/app/views/admin/members/new.html.haml
+++ b/app/views/admin/members/new.html.haml
@@ -126,7 +126,7 @@
                 - unless ENV['MAILCHIMP_DATACENTER'].blank?
                   .form-group
                     = f.label(:mailchimp_interests)
-                    = f.select :mailchimp_interests, options_for_select( Rails.configuration.mailchimp_interests, NIL), { :include_blank => true }, :multiple => true, :name => 'member[mailchimp_interests][]', :class => 'form-control'
+                    = f.select :mailchimp_interests, options_for_select( Rails.configuration.mailchimp_interests ), { :include_blank => true }, :multiple => true, :name => 'member[mailchimp_interests][]', :class => 'form-control'
 
         .col-md-12
           .card


### PR DESCRIPTION
Fixes #978 

`NIL` is undefined, which is why the crash happens (the correct spelling is `nil`).
How this has been undiscovered for 2 years is a bit of a mystery to me.
The extra argument to `options_for_select` isn't needed, so I removed it.