### PR TITLE
set x-accel-redirect correctly

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'XSendfile' # for Apache
-  config.action_dispatch.x_sendfile_header = 'XAccelRedirect' # for NGINX
+  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'XSendfile' # for Apache
-  config.action_dispatch.x_sendfile_header = 'XAccelRedirect' # for NGINX
+  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
We have a lot of log messages that state: `Unknown x-sendfile variation: 'XAccelRedirect'.`
According to the docs, the setting should be spelled with dashes instead (https://guides.rubyonrails.org/asset_pipeline.html#x-sendfile-headers).