### PR TITLE
Rubocop: Enforce the use of function parentheses, and auto-fix all offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,10 +33,10 @@ Metrics/MethodLength:
 
 # Allow 'some.variable == 0' and others
 Style/NumericPredicate:
-  Enabled: False
+  Enabled: false
 
 Layout/LineLength:
-  Enabled: True
+  Enabled: true
 
 # Require spaces in string interpolation "#{ meme }" instead of "#{meme}"
 Layout/SpaceInsideStringInterpolation:
@@ -115,3 +115,6 @@ Rails/ApplicationController:
 # Let Rubocop know we have a staging environment
 Rails/UnknownEnv:
   Environments: development, test, staging, production
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true

--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -12,7 +12,7 @@ class Admin::ActivitiesController < ApplicationController
   def show
     @is_summarized = params['summary_only'] || params['summary_csv']
     @is_summarized_as_csv = params['summary_csv']
-    @activity = Activity.find params[:id]
+    @activity = Activity.find(params[:id])
     @recipients = @activity.payment_mail_recipients
     @attendees  = @activity.ordered_attendees
     @reservists = @activity.ordered_reservists
@@ -24,43 +24,43 @@ class Admin::ActivitiesController < ApplicationController
     if @activity.save
       # manual call to impressionist, because otherwise the activity doesn't have an id yet
       impressionist(@activity)
-      redirect_to @activity
+      redirect_to(@activity)
     else
       @activities = Activity.all.order(start_date: :desc)
       @years = (Activity.take(1).first.start_date.year..Date.today.study_year).map { |year| ["#{ year }-#{ year + 1 }", year] }.reverse
 
       @detailed = Activity.debtors.sort_by(&:start_date).reverse!
 
-      render 'index'
+      render('index')
     end
   end
 
   # TODO: refactor
   def update
-    @activity = Activity.find params[:id]
+    @activity = Activity.find(params[:id])
     params = activity_post_params
 
     # removing the images from disk
     if params[:_destroy] == 'true'
-      logger.debug 'remove poster from activity'
+      logger.debug('remove poster from activity')
       @activity.poster.purge
     end
 
     if @activity.update(params.except(:_destroy))
-      redirect_to @activity
+      redirect_to(@activity)
     else
       @recipients = @activity.payment_mail_recipients
       @attendees  = @activity.ordered_attendees
       @reservists = @activity.ordered_reservists
-      render 'show'
+      render('show')
     end
   end
 
   def destroy
-    @activity = Activity.find params[:id]
+    @activity = Activity.find(params[:id])
     @activity.destroy
 
-    redirect_to activities_path
+    redirect_to(activities_path)
   end
 
   private

--- a/app/controllers/admin/api_controller.rb
+++ b/app/controllers/admin/api_controller.rb
@@ -9,7 +9,7 @@ class Admin::ApiController < ApplicationController
 
   # are these functions even used? I can't find them in routes, I suggest moving it the controllers/api
   def activities
-    render status: :ok,
-           json: Activity.list.only(:name, :start_date, :end_date, :poster)
+    render(status: :ok,
+           json: Activity.list.only(:name, :start_date, :end_date, :poster))
   end
 end

--- a/app/controllers/admin/checkout_products_controller.rb
+++ b/app/controllers/admin/checkout_products_controller.rb
@@ -10,7 +10,7 @@ class Admin::CheckoutProductsController < ApplicationController
 
     @new = CheckoutProduct.new
 
-    render 'admin/apps/products'
+    render('admin/apps/products')
   end
 
   def show
@@ -20,43 +20,43 @@ class Admin::CheckoutProductsController < ApplicationController
     @product = CheckoutProduct.find_by(id: params[:id])
     @total = @product.sales(params['year']).map { |sale| sale.first[0].price * sale.first[1] unless sale.first[1].nil? }.compact.inject(:+)
 
-    render 'admin/apps/products'
+    render('admin/apps/products')
   end
 
   def create
-    @new = CheckoutProduct.new product_post_params
+    @new = CheckoutProduct.new(product_post_params)
 
     if @new.save
-      redirect_to checkout_product_path(@new)
+      redirect_to(checkout_product_path(@new))
     else
       @products = CheckoutProduct.order(:category, :name).last_version
       @years = (2015..Date.today.study_year).map { |year| ["#{ year }-#{ year + 1 }", year] }.reverse
 
-      render 'admin/apps/products'
+      render('admin/apps/products')
     end
   end
 
   def update
-    @product = CheckoutProduct.find_by id: params[:id]
+    @product = CheckoutProduct.find_by(id: params[:id])
 
     if @product.update(product_post_params)
       # if a new product is created redirect to it
       product = CheckoutProduct.find_by(parent: @product.id)
       prod_id = product ? product.id.to_s : @product.id.to_s
 
-      redirect_to checkout_product_path(product || @product.id, anchor: "product_#{ prod_id }")
+      redirect_to(checkout_product_path(product || @product.id, anchor: "product_#{ prod_id }"))
     else
       @years = (2015..Date.today.study_year).map { |year| ["#{ year }-#{ year + 1 }", year] }.reverse
       @products = CheckoutProduct.order(:category, :name).last_version
 
-      render 'admin/apps/products'
+      render('admin/apps/products')
     end
   end
 
   def flip_active
-    @product = CheckoutProduct.find params[:checkout_product_id]
+    @product = CheckoutProduct.find(params[:checkout_product_id])
 
-    head :internal_server_error unless @product.update(product_flipactive_params)
+    head(:internal_server_error) unless @product.update(product_flipactive_params)
   end
 
   def change_funds
@@ -68,17 +68,17 @@ class Admin::CheckoutProductsController < ApplicationController
       transaction = CheckoutTransaction.new(price: params[:amount], checkout_balance: CheckoutBalance.find_by!(member_id: params[:member_id]), payment_method: params[:payment_method])
 
     else
-      render status: :bad_request, json: I18n.t('checkout.error.identifier')
+      render(status: :bad_request, json: I18n.t('checkout.error.identifier'))
       return
     end
 
     if transaction.save
-      impressionist transaction
-      render status: :created, json: transaction
+      impressionist(transaction)
+      render(status: :created, json: transaction)
     else
-      render status: :bad_request, json: {
-        errors: transaction.errors
-      }
+      render(status: :bad_request, json: {
+               errors: transaction.errors
+             })
     end
   end
 
@@ -88,17 +88,17 @@ class Admin::CheckoutProductsController < ApplicationController
     if params[:_destroy]
       card.destroy
 
-      render status: :no_content, json: ''
+      render(status: :no_content, json: '')
       return
     end
 
     card.update(active: true)
 
     if card.save
-      impressionist card
-      render status: :ok, json: card.to_json
+      impressionist(card)
+      render(status: :ok, json: card.to_json)
     else
-      render status: :bad_request, json: card.errors.full_messages
+      render(status: :bad_request, json: card.errors.full_messages)
     end
   end
 

--- a/app/controllers/admin/group_members_controller.rb
+++ b/app/controllers/admin/group_members_controller.rb
@@ -3,22 +3,22 @@ class Admin::GroupMembersController < ApplicationController
   def create
     @member = GroupMember.new(member: Member.find_by(id: params[:member]), group: Group.find_by(id: params[:group_id]), year: params[:year])
 
-    head :bad_request unless @member.save
+    head(:bad_request) unless @member.save
 
-    impressionist @member
-    render status: :created
+    impressionist(@member)
+    render(status: :created)
   end
 
   def update
     @member = GroupMember.find_by(id: params[:id])
 
-    head :bad_request unless @member.update(position: params[:position])
+    head(:bad_request) unless @member.update(position: params[:position])
 
-    impressionist @member
-    head :no_content
+    impressionist(@member)
+    head(:no_content)
   end
 
   def destroy
-    head :no_content if GroupMember.destroy(params[:id])
+    head(:no_content) if GroupMember.destroy(params[:id])
   end
 end

--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -10,30 +10,30 @@ class Admin::GroupsController < ApplicationController
 
   def show
     @groups = Group.all.order(:category, :name)
-    @group = Group.find_by id: params[:id]
+    @group = Group.find_by(id: params[:id])
   end
 
   def create
-    @group = Group.new group_params
+    @group = Group.new(group_params)
 
     if @group.save
-      impressionist @group
-      redirect_to @group
+      impressionist(@group)
+      redirect_to(@group)
     else
       @groups = Group.all.order(:category, :name)
-      render 'show'
+      render('show')
     end
   end
 
   def update
-    @group = Group.find_by id: params[:id]
+    @group = Group.find_by(id: params[:id])
 
     if @group.update(group_params)
-      impressionist @group
-      redirect_to @group
+      impressionist(@group)
+      redirect_to(@group)
     else
       @groups = Group.all.order(:category, :name)
-      render 'show'
+      render('show')
     end
   end
 
@@ -41,10 +41,10 @@ class Admin::GroupsController < ApplicationController
     @group = Group.find(params[:id])
 
     if @group.category == "board"
-      redirect_to group_path
+      redirect_to(group_path)
     else
       @group.destroy
-      redirect_to groups_path
+      redirect_to(groups_path)
     end
   end
 

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -24,7 +24,7 @@ class Admin::ParticipantsController < ApplicationController
       message = params[:paid].to_b ? 'paid' : 'unpaid'
       @participant.update(paid: params[:paid]) unless @participant.currency.nil?
     elsif params[:price].present?
-      raise 'not a number' unless params[:price].is_number?
+      raise('not a number') unless params[:price].is_number?
 
       message = 'price'
       @participant.update(price: params[:price])
@@ -32,23 +32,23 @@ class Admin::ParticipantsController < ApplicationController
 
     if @participant.save
       impressionist(@participant, message)
-      render status: :ok
+      render(status: :ok)
     end
   end
 
   def destroy
-    ghost = Participant.destroy params[:id]
+    ghost = Participant.destroy(params[:id])
 
     @activity = ghost.activity
     @reservists = @activity.enroll_reservists!
 
-    render status: :ok
+    render(status: :ok)
   end
 
   def mail
     # TODO: it looks like the http post response is returned to the user, if that is the case it should be changed to `head :ok`
     @activity = Activity.find(params[:activity_id])
-    render json: Mailings::Participants.inform(@activity, params[:recipients].permit!.to_h.map { |_, item| item['email'] }, current_user.sender, params[:subject], params[:html]).deliver_later
+    render(json: Mailings::Participants.inform(@activity, params[:recipients].permit!.to_h.map { |_, item| item['email'] }, current_user.sender, params[:subject], params[:html]).deliver_later)
     impressionist(@activity, "mail")
   end
 end

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -37,18 +37,18 @@ class Admin::PaymentsController < ApplicationController
     @member = Member.find(params[:member_id])
     @activities = @member.unpaid_activities.where('activities.start_date <= ?', Date.today).distinct
     @participants = @activities.map { |a| Participant.find_by(member: @member, activity: a) }
-    msg = render_to_string template: 'admin/members/payment_whatsapp.html.haml', layout: false, content_type: "text/plain"
+    msg = render_to_string(template: 'admin/members/payment_whatsapp.html.haml', layout: false, content_type: "text/plain")
 
     pn = @member.phone_number
 
-    redirect_to "https://web.whatsapp.com/send?phone=#{ pn }&text=#{ ERB::Util.url_encode msg }"
+    redirect_to("https://web.whatsapp.com/send?phone=#{ pn }&text=#{ ERB::Util.url_encode(msg) }")
   end
 
   def update_transactions
     checkout_transactions = CheckoutTransaction.where('DATE(checkout_transactions.created_at) = DATE(?) AND payment_method = \'Gepind\'', params[:start_date]).order(created_at: :desc)
     data = checkout_transactions.map { |x| { member_id: x.checkout_balance.member.id, name: x.checkout_balance.member.name, price: x.price, date: x.created_at.to_date } }
 
-    render json: data
+    render(json: data)
   end
 
   def export_payments
@@ -62,9 +62,9 @@ class Admin::PaymentsController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_to payments_path }
-      format.csv { send_data @transaction_file, filename: "payments_#{ Date.strptime(params[:start_date], '%Y-%m-%d') }_#{ Date.strptime(params[:end_date], '%Y-%m-%d') }.csv" }
-      format.js { render js: "window.open(\"#{ transactions_export_path(format: :csv, start_date: params[:start_date], end_date: params[:end_date], payment_type: payment_type, export_type: params[:export_type]) }\", \"_blank\")" }
+      format.html { redirect_to(payments_path) }
+      format.csv { send_data(@transaction_file, filename: "payments_#{ Date.strptime(params[:start_date], '%Y-%m-%d') }_#{ Date.strptime(params[:end_date], '%Y-%m-%d') }.csv") }
+      format.js { render(js: "window.open(\"#{ transactions_export_path(format: :csv, start_date: params[:start_date], end_date: params[:end_date], payment_type: payment_type, export_type: params[:export_type]) }\", \"_blank\")") }
     end
   end
 

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -2,36 +2,36 @@
 class Admin::PostsController < ApplicationController
   def index
     @pagination, @posts = pagination_posts
-    @post = Post.new author: current_user.credentials
+    @post = Post.new(author: current_user.credentials)
   end
 
   def create
     @post = Post.new(post_params)
 
     if @post.save
-      redirect_to @post
+      redirect_to(@post)
     else
       @pagination, @posts = pagination_posts
-      render 'index'
+      render('index')
     end
   end
 
   def show
     @pagination, @posts = pagination_posts
-    @post = Post.find_by id: params[:id]
-    render 'index'
+    @post = Post.find_by(id: params[:id])
+    render('index')
   end
 
   def update
-    @post = Post.find_by id: params[:id]
+    @post = Post.find_by(id: params[:id])
     @post.update(post_params)
     @pagination, @posts = pagination_posts
-    render 'index'
+    render('index')
   end
 
   def destroy
     Post.destroy(params[:id])
-    redirect_to :posts
+    redirect_to(:posts)
   end
 
   private

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -12,37 +12,37 @@ class Admin::SettingsController < ApplicationController
   end
 
   def create
-    if ['additional_positions.moot', 'additional_positions.committee'].include? params[:setting]
+    if ['additional_positions.moot', 'additional_positions.committee'].include?(params[:setting])
       Settings[params[:setting]] = params[:value].downcase.split(',').each(&:strip!)
 
-    elsif ['intro.membership', 'intro.activities'].include? params[:setting]
+    elsif ['intro.membership', 'intro.activities'].include?(params[:setting])
       Settings[params[:setting]] = Activity.where(id: params[:value].split(',').map(&:to_i)).collect(&:id)
 
-      render status: :ok, json: {
-        activities: Settings[params[:setting]],
-        warning: params[:value].split(',').map(&:to_i).count != Settings[params[:setting]].count
-      }
+      render(status: :ok, json: {
+               activities: Settings[params[:setting]],
+               warning: params[:value].split(',').map(&:to_i).count != Settings[params[:setting]].count
+             })
       return
-    elsif %w[mongoose_ideal_costs].include? params[:setting]
+    elsif %w[mongoose_ideal_costs].include?(params[:setting])
       head(:bad_request) && return if (params[:value] =~ /\d{1,}[,.]\d{2}/).nil?
 
       Settings[params[:setting]] = params[:value].sub(',', '.').to_f
-    elsif ['begin_study_year'].include? params[:setting]
+    elsif ['begin_study_year'].include?(params[:setting])
       head(:bad_request) && return if (params[:value] =~ /\d{4}-\d{2}-\d{2}/).nil?
 
       Settings[params[:setting]] = Date.parse(params[:value])
-    elsif ['liquor_time'].include? params[:setting]
+    elsif ['liquor_time'].include?(params[:setting])
       head(:bad_request) && return if (params[:value] =~ /\d{2}:\d{2}/).nil?
 
       Settings[params[:setting]] = params[:value]
-    elsif %w[ideal_relation_code payment_condition_code mongoose_ledger_number accountancy_ledger_number].include? params[:setting]
+    elsif %w[ideal_relation_code payment_condition_code mongoose_ledger_number accountancy_ledger_number].include?(params[:setting])
       head(:bad_request) && return if (params[:value] =~ /\d+/).nil?
 
       Settings[params[:setting]] = params[:value]
-    elsif ['accountancy_cost_location'].include? params[:setting]
+    elsif ['accountancy_cost_location'].include?(params[:setting])
       Settings[params[:setting]] = params[:value]
     end
-    head :ok
+    head(:ok)
     return
   end
 
@@ -53,7 +53,7 @@ class Admin::SettingsController < ApplicationController
     @admin = Admin.find(current_user.credentials_id)
     @admin.update(admin_post_params)
 
-    return redirect_to request.referer, notice: I18n.t("activerecord.errors.info")
+    return redirect_to(request.referer, notice: I18n.t("activerecord.errors.info"))
   end
 
   def logs

--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -17,13 +17,13 @@ class Api::ActivitiesController < ApiController
   end
 
   def poster
-    @activity = Activity.find params[:activity_id]
-    redirect_to url_for @activity.poster_representation
+    @activity = Activity.find(params[:activity_id])
+    redirect_to(url_for(@activity.poster_representation))
   end
 
   def thumbnail
-    @activity = Activity.find params[:activity_id]
-    redirect_to url_for @activity.thumbnail_representation
+    @activity = Activity.find(params[:activity_id])
+    redirect_to(url_for(@activity.thumbnail_representation))
   end
 
   def show
@@ -37,6 +37,6 @@ class Api::ActivitiesController < ApiController
 
     return if valid_doorkeeper_token? || user_signed_in?
 
-    head :unauthorized
+    head(:unauthorized)
   end
 end

--- a/app/controllers/api/checkout_controller.rb
+++ b/app/controllers/api/checkout_controller.rb
@@ -28,7 +28,7 @@ class Api::CheckoutController < ActionController::Base
   def info
     @card = CheckoutCard.joins(:member, :checkout_balance).select(:id, :uuid, :first_name, :balance, :active).find_by(uuid: params[:uuid])
 
-    return head :not_found unless @card
+    return head(:not_found) unless @card
   end
 
   def purchase
@@ -37,12 +37,12 @@ class Api::CheckoutController < ActionController::Base
     transaction = CheckoutTransaction.new(items: ahelper(params[:items]), checkout_card: card)
 
     if transaction.save!
-      render status: :created, json: {
-        uuid: card.uuid,
-        first_name: card.member.first_name,
-        balance: card.checkout_balance.balance + transaction.price,
-        created_at: transaction.created_at
-      }
+      render(status: :created, json: {
+               uuid: card.uuid,
+               first_name: card.member.first_name,
+               balance: card.checkout_balance.balance + transaction.price,
+               created_at: transaction.created_at
+             })
     else
       i18n_scope = %i[activerecord errors models checkout_transaction attributes]
 
@@ -51,20 +51,20 @@ class Api::CheckoutController < ActionController::Base
 
       case transaction.errors
       when transaction.errors[:items].includes(not_liquor_time_translation)
-        render status: :not_acceptable, json: {
-          message: not_liquor_time_translation
-        }
+        render(status: :not_acceptable, json: {
+                 message: not_liquor_time_translation
+               })
       when transaction.errors[:price].includes(insufficient_credit_translation)
-        render status: :payload_too_large, json: {
-          message: I18n.t(insufficient_credit_translation, scope: i18n_scope),
-          balance: card.checkout_balance.balance,
-          items: ahelper(params[:items]),
-          costs: transaction.price
-        }
+        render(status: :payload_too_large, json: {
+                 message: I18n.t(insufficient_credit_translation, scope: i18n_scope),
+                 balance: card.checkout_balance.balance,
+                 items: ahelper(params[:items]),
+                 costs: transaction.price
+               })
       else
-        render status: :bad_request, json: {
-          errors: transaction.errors
-        }
+        render(status: :bad_request, json: {
+                 errors: transaction.errors
+               })
       end
     end
   end
@@ -76,15 +76,15 @@ class Api::CheckoutController < ActionController::Base
 
     if card.save
       card.send_confirmation!
-      render status: :created, json: CheckoutCard.joins(:member, :checkout_balance).select(:id, :uuid, :first_name, :balance).find_by!(uuid: params[:uuid]).to_json
+      render(status: :created, json: CheckoutCard.joins(:member, :checkout_balance).select(:id, :uuid, :first_name, :balance).find_by!(uuid: params[:uuid]).to_json)
     else
-      head :conflict
+      head(:conflict)
     end
   end
 
   def confirm
     card = CheckoutCard.where(confirmation_token: params['confirmation_token']).first
-    redirect_to :new_user_session
+    redirect_to(:new_user_session)
 
     if card.nil?
       flash[:alert] = I18n.t('checkout.card.nil')
@@ -120,7 +120,7 @@ class Api::CheckoutController < ActionController::Base
   # TODO: implement for OAuth client credentials
   def authenticate_checkout
     if params[:token] != ENV['CHECKOUT_TOKEN']
-      head :forbidden
+      head(:forbidden)
       nil
     end
   end
@@ -128,9 +128,9 @@ class Api::CheckoutController < ActionController::Base
   def authenticate_card
     @uuid = params[:uuid]
     @card = CheckoutCard.find_by(uuid: @uuid)
-    render status: :not_found && return if @card.nil?
-    render status: :unauthorized, json: I18n.t('checkout.error.not_activated') unless @card.active
-    render status: :unauthorized, json: I18n.t('checkout.error.disabled') if @card.disabled
+    render(status: :not_found && return) if @card.nil?
+    render(status: :unauthorized, json: I18n.t('checkout.error.not_activated')) unless @card.active
+    render(status: :unauthorized, json: I18n.t('checkout.error.disabled')) if @card.disabled
     (@card.active and !@card.disabled)
   end
 end

--- a/app/controllers/api/groups_controller.rb
+++ b/app/controllers/api/groups_controller.rb
@@ -1,6 +1,6 @@
 #:nodoc:
 class Api::GroupsController < ApiController
-  before_action -> { doorkeeper_authorize! 'group-read' }, only: [:index, :show]
+  before_action -> { doorkeeper_authorize!('group-read') }, only: [:index, :show]
 
   def index
     (@groups = Group.where(category: params[:category]).order(:name)) && return unless params[:category].nil?

--- a/app/controllers/api/internal_controller.rb
+++ b/app/controllers/api/internal_controller.rb
@@ -7,27 +7,27 @@ class Api::InternalController < ActionController::Base
 
   def member_by_studentid
     @mongoose_user = Member.select(:id, :first_name, :infix, :last_name, :birth_date, :email).find_by(student_id: params[:student_number])
-    return head :no_content unless @mongoose_user
+    return head(:no_content) unless @mongoose_user
   end
 
   def member_by_id
     @mongoose_user = Member.select(:id, :first_name, :infix, :last_name, :birth_date).find(params[:id])
-    return head :no_content unless @mongoose_user
+    return head(:no_content) unless @mongoose_user
   end
 
   def authenticate_internal
     return unless request.headers['Authorization'] != ENV['CHECKOUT_TOKEN']
 
-    head :forbidden
+    head(:forbidden)
     nil
   end
 
   def authenticate_card
     @uuid = params[:uuid]
     @card = CheckoutCard.find_by(uuid: @uuid)
-    render status: :not_found && return if @card.nil?
-    render status: :unauthorized, json: I18n.t('checkout.error.not_activated') unless @card.active
-    render status: :unauthorized, json: I18n.t('checkout.error.disabled') if @card.disabled
+    render(status: :not_found && return) if @card.nil?
+    render(status: :unauthorized, json: I18n.t('checkout.error.not_activated')) unless @card.active
+    render(status: :unauthorized, json: I18n.t('checkout.error.disabled')) if @card.disabled
     (@card.active and !@card.disabled)
   end
 end

--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -1,6 +1,6 @@
 #:nodoc:
 class Api::MembersController < ApiController
-  before_action -> { doorkeeper_authorize! 'member-read' }, only: [:index, :show]
+  before_action -> { doorkeeper_authorize!('member-read') }, only: [:index, :show]
 
   def index
     @members = Member.all.order(:last_name, :first_name).offset(params[:offset] ||= 0).limit(params[:limit] ||= 20)
@@ -8,7 +8,7 @@ class Api::MembersController < ApiController
 
   # TODO: alternatief voor intro.svsticky.nl
   def create
-    raise NotImplementedError
+    raise(NotImplementedError)
   end
 
   def show

--- a/app/controllers/api/participants_controller.rb
+++ b/app/controllers/api/participants_controller.rb
@@ -1,7 +1,7 @@
 #:nodoc:
 class Api::ParticipantsController < ApiController
-  before_action -> { doorkeeper_authorize! 'participant-read' }, only: :index
-  before_action -> { doorkeeper_authorize! 'participant-write' }, only: [:create, :update, :destroy]
+  before_action -> { doorkeeper_authorize!('participant-read') }, only: :index
+  before_action -> { doorkeeper_authorize!('participant-write') }, only: [:create, :update, :destroy]
 
   def index
     if params[:activity_id].present?
@@ -13,7 +13,7 @@ class Api::ParticipantsController < ApiController
       @participants = Participant.where(member: Authorization._member).includes(:activity, :member)
 
     else
-      head :bad_request
+      head(:bad_request)
       return
     end
   end
@@ -22,21 +22,21 @@ class Api::ParticipantsController < ApiController
     @participant = Participant.new(member: Authorization._member, activity: Activity.find(params[:activity_id]))
     head(:bad_request) && return unless @participant.save
 
-    render status: :created
+    render(status: :created)
   end
 
   def update
-    raise NotImplementedError
+    raise(NotImplementedError)
   end
 
   # TODO: uitschrijfdeadline hierin meenemen
   def destroy
-    participant = Participant.find_by! member_id: Authorization._member.id, activity_id: params[:activity_id]
+    participant = Participant.find_by!(member_id: Authorization._member.id, activity_id: params[:activity_id])
 
     head(:locked) && return if participant.paid
     head(:locked) && return if participant.activity.start_date <= Date.today
 
     participant.destroy!
-    head :no_content
+    head(:no_content)
   end
 end

--- a/app/controllers/api/webhook_controller.rb
+++ b/app/controllers/api/webhook_controller.rb
@@ -6,37 +6,37 @@ class Api::WebhookController < ApiController
 
     flash[:notice] = transaction.message if transaction.successful? || transaction.in_progress?
 
-    logger.debug transaction.message.inspect
+    logger.debug(transaction.message.inspect)
 
     flash[:warning] = transaction.message if transaction.failed?
 
-    redirect_to transaction.redirect_uri
+    redirect_to(transaction.redirect_uri)
   end
 
   def mollie_hook
     transaction = Payment.find_by!(trxid: params[:id])
     transaction.finalize! if transaction.update_transaction!
 
-    head :ok
+    head(:ok)
   end
 
   # send ok status to convince mailchimp everything works
   def mailchimp_confirm_callback
     head(:unauthorized) && return unless params[:token] == ENV['MAILCHIMP_SECRET']
 
-    head :ok
+    head(:ok)
   end
 
   # invalidate cache on mailchimp change
   def mailchimp
     head(:unauthorized) && return unless params[:token] == ENV['MAILCHIMP_SECRET']
     head(:precondition_failed) && return unless params[:data][:list_id] == ENV['MAILCHIMP_LIST_ID']
-    head(:method_not_allowed) && return unless ['subscribe', 'unsubscribe', 'profile', 'cleaned'].include? params[:type]
+    head(:method_not_allowed) && return unless ['subscribe', 'unsubscribe', 'profile', 'cleaned'].include?(params[:type])
 
-    member = Member.find_by! email: params[:data][:email]
+    member = Member.find_by!(email: params[:data][:email])
 
     Rails.cache.delete("members/#{ member.id }/mailchimp/interests")
 
-    head :no_content
+    head(:no_content)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate_admin!
     if !current_user.nil? && !current_user.admin?
-      head :forbidden
+      head(:forbidden)
       return
     end
   end

--- a/app/controllers/members/activities_controller.rb
+++ b/app/controllers/members/activities_controller.rb
@@ -34,7 +34,7 @@ class Members::ActivitiesController < ApplicationController
     @activity = Activity.find(params[:id])
 
     # Don't allow activities for old activities
-    render :unavailable, status: :gone if @activity.ended? || !@activity.is_viewable?
+    render(:unavailable, status: :gone) if @activity.ended? || !@activity.is_viewable?
 
     @enrollment = Participant.find_by(
       member_id: @member.id,

--- a/app/controllers/members/participants_controller.rb
+++ b/app/controllers/members/participants_controller.rb
@@ -21,9 +21,9 @@ class Members::ParticipantsController < ApplicationController
   def create
     # Don't allow signups for old activities
     if @activity.ended?
-      render status: :gone, json: {
-        message: I18n.t(:activity_ended, scope: @activity_errors_scope)
-      }
+      render(status: :gone, json: {
+               message: I18n.t(:activity_ended, scope: @activity_errors_scope)
+             })
       return
     end
 
@@ -33,55 +33,55 @@ class Members::ParticipantsController < ApplicationController
 
     # Deny if already enrolled
     if Participant.exists?(activity: @activity, member: @member)
-      render status: :conflict, json: {
-        message: I18n.t(:already_enrolled, scope: @activity_errors_scope)
-      }
+      render(status: :conflict, json: {
+               message: I18n.t(:already_enrolled, scope: @activity_errors_scope)
+             })
       return
     # Deny members that don't have an active study, unless the member is a
     # pardon, merit or honary member or donator.
     elsif !@member.may_enroll?
-      render status: :failed_dependency, json: {
-        message: I18n.t(:participant_no_student, scope: @activity_errors_scope),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :failed_dependency, json: {
+               message: I18n.t(:participant_no_student, scope: @activity_errors_scope),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     # Deny suspended members
     elsif Tag.exists?(member: @member, name: Tag.names[:suspended])
-      render status: :failed_dependency, json: {
-        message: I18n.t(:participant_suspended, scope: @activity_errors_scope),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :failed_dependency, json: {
+               message: I18n.t(:participant_suspended, scope: @activity_errors_scope),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     # Deny if activity not enrollable
     elsif !@activity.open?
-      render status: :locked, json: {
-        message: I18n.t(:not_enrollable, scope: @activity_errors_scope),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :locked, json: {
+               message: I18n.t(:not_enrollable, scope: @activity_errors_scope),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     # Deny minors from alcoholic activities
     elsif participant_alcohol_check?
-      render status: :unavailable_for_legal_reasons, json: {
-        message: I18n.t(:participant_underage, scope: @activity_errors_scope, activity: @activity.name),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :unavailable_for_legal_reasons, json: {
+               message: I18n.t(:participant_underage, scope: @activity_errors_scope, activity: @activity.name),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     # Check if notes are present and deny if absent and required.
     elsif participant_notes_check?
       # Notify that notes are required
-      render status: :precondition_failed, json: {
-        message: I18n.t(
-          :participant_notes_not_filled,
-          scope: @activity_errors_scope,
-          activity: @activity.name
-        ),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :precondition_failed, json: {
+               message: I18n.t(
+                 :participant_notes_not_filled,
+                 scope: @activity_errors_scope,
+                 activity: @activity.name
+               ),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     elsif participant_limit_check?
       reservist = true
@@ -115,11 +115,11 @@ class Members::ParticipantsController < ApplicationController
                                   scope: @activity_errors_scope,
                                   activity: @activity.name)
 
-      render status: :accepted, json: {
-        message: "#{ reason_for_spare_message } #{ spare_list_message }",
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :accepted, json: {
+               message: "#{ reason_for_spare_message } #{ spare_list_message }",
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     else
       @new_enrollment = Participant.new(
@@ -131,13 +131,13 @@ class Members::ParticipantsController < ApplicationController
 
       @new_enrollment.save!
 
-      render status: :ok, json: {
-        message: I18n.t(:enrolled, scope:
-          @activity_errors_scope, activity:
-                          @activity.name),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :ok, json: {
+               message: I18n.t(:enrolled, scope:
+                 @activity_errors_scope, activity:
+                                 @activity.name),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
     end
   end
 
@@ -187,25 +187,25 @@ class Members::ParticipantsController < ApplicationController
     if @activity.notes.blank? || params[:par_notes].present?
       @enrollment.update(notes: params[:par_notes])
       @enrollment.save
-      render status: :accepted, json: {
-        message: I18n.t(
-          :participant_notes_updated,
-          scope: @activity_errors_scope,
-          activity: @activity.name
-        ),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :accepted, json: {
+               message: I18n.t(
+                 :participant_notes_updated,
+                 scope: @activity_errors_scope,
+                 activity: @activity.name
+               ),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
     else
-      render status: :precondition_failed, json: {
-        message: I18n.t(
-          :participant_notes_not_filled,
-          scope: @activity_errors_scope,
-          activity: @activity.name
-        ),
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :precondition_failed, json: {
+               message: I18n.t(
+                 :participant_notes_not_filled,
+                 scope: @activity_errors_scope,
+                 activity: @activity.name
+               ),
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
     end
   end
 
@@ -238,11 +238,11 @@ class Members::ParticipantsController < ApplicationController
         message = I18n.t(:unenroll_date_passed, scope: @activity_errors_scope)
       end
 
-      render status: :locked, json: {
-        message: message,
-        participant_limit: @activity.participant_limit,
-        participant_count: @activity.participants.count
-      }
+      render(status: :locked, json: {
+               message: message,
+               participant_limit: @activity.participant_limit,
+               participant_count: @activity.participants.count
+             })
       return
     end
 
@@ -250,15 +250,15 @@ class Members::ParticipantsController < ApplicationController
     @enrollment.destroy!
     activity.enroll_reservists!
 
-    render status: :ok, json: {
-      message: I18n.t(
-        :unenrolled,
-        scope: @activity_errors_scope,
-        activity: @activity.name
-      ),
-      participant_limit: @activity.participant_limit,
-      participant_count: @activity.participants.count
-    }
+    render(status: :ok, json: {
+             message: I18n.t(
+               :unenrolled,
+               scope: @activity_errors_scope,
+               activity: @activity.name
+             ),
+             participant_limit: @activity.participant_limit,
+             participant_count: @activity.participants.count
+           })
   end
 
   private
@@ -269,11 +269,11 @@ class Members::ParticipantsController < ApplicationController
 
     # Don't allow activities for old activities
     if @activity.ended? || !@activity.is_viewable? # rubocop:disable Style/GuardClause
-      render status: :gone,
+      render(status: :gone,
              plain: I18n.t(
                :activity_ended,
                scope: 'activerecord.errors.models.activity'
-             )
+             ))
     end
   end
 end

--- a/app/controllers/members/payments_controller.rb
+++ b/app/controllers/members/payments_controller.rb
@@ -26,7 +26,7 @@ class Members::PaymentsController < ApplicationController
 
     if amount < 1
       flash[:warning] = I18n.t('failed', scope: 'activerecord.errors.models.payment')
-      redirect_to member_payments_path
+      redirect_to(member_payments_path)
       return
     end
     payment = Payment.new(
@@ -40,15 +40,15 @@ class Members::PaymentsController < ApplicationController
       redirect_uri: member_payments_path
     )
     if payment.save
-      redirect_to payment.payment_uri
+      redirect_to(payment.payment_uri)
     else
       flash[:notice] = I18n.t('failed', scope: 'activerecord.errors.models.payment')
-      redirect_to member_payments_path
+      redirect_to(member_payments_path)
     end
   end
 
   def self.join_with_char_limit(collection, separator, maxlength)
-    all_joined = collection.join separator
+    all_joined = collection.join(separator)
     return all_joined if all_joined.length <= maxlength
 
     suffix_mkr = ->(cnt) { " & #{ cnt } meer" }
@@ -62,7 +62,7 @@ class Members::PaymentsController < ApplicationController
       remaining_length -= collection[index].length + separator.length
       if remaining_length < 0
         slice = collection.slice(0, index)
-        return "#{ slice.join separator } & #{ collection.length - index } meer"
+        return "#{ slice.join(separator) } & #{ collection.length - index } meer"
       end
     end
 
@@ -77,13 +77,13 @@ class Members::PaymentsController < ApplicationController
 
     if amount < 1
       flash[:warning] = I18n.t('failed', scope: 'activerecord.errors.models.payment')
-      redirect_to member_payments_path
+      redirect_to(member_payments_path)
       return
     end
 
     if balance.nil?
       flash[:warning] = I18n.t('failed', scope: 'activerecord.errors.models.payment')
-      redirect_to member_payments_path
+      redirect_to(member_payments_path)
       return
     end
 
@@ -99,10 +99,10 @@ class Members::PaymentsController < ApplicationController
       redirect_uri: member_payments_path
     )
     if payment.save
-      redirect_to payment.payment_uri
+      redirect_to(payment.payment_uri)
     else
       flash[:warning] = I18n.t('failed', scope: 'activerecord.errors.models.payment')
-      redirect_to members_home_path
+      redirect_to(members_home_path)
     end
   end
 

--- a/app/controllers/public/status_controller.rb
+++ b/app/controllers/public/status_controller.rb
@@ -16,34 +16,34 @@ class Public::StatusController < PublicController
     flash[:notice] = []
 
     if @member.update(member_post_params)
-      impressionist @member
+      impressionist(@member)
 
-      if @member.educations.none?(&:active?) && !(%w[yearly indefinite].include? @member.consent)
+      if @member.educations.none?(&:active?) && %w[yearly indefinite].exclude?(@member.consent)
         @member.errors.add(:base, I18n.t('activerecord.errors.no_consent'))
         flash[:errors] = @member.errors.messages
 
         @member.educations.build(id: -1)
-        render 'edit'
+        render('edit')
         return
       end
 
       @token.destroy
       flash[:notice] << 'success!'
 
-      redirect_to users_root_url
+      redirect_to(users_root_url)
       return
     end
 
     flash[:errors] = @member.errors.messages
     @member.educations.build(id: -1)
-    render 'edit'
+    render('edit')
   end
 
   def destroy
     @token = Token.find_by!(token: params[:token], intent: :consent)
     @member = Member.includes(:checkout_balance).find(@token.object.id)
 
-    impressionist @member
+    impressionist(@member)
     flash[:notice] = []
 
     # update studies one last time if possible
@@ -55,12 +55,12 @@ class Public::StatusController < PublicController
       flash[:notice] << I18n.t('activerecord.errors.models.member.destroy.info', name: @member.name)
       flash[:notice] << I18n.t('activerecord.errors.models.member.destroy.checkout_emptied', balance: view_context.number_to_currency(@member.checkout_balance.balance, unit: '€')) unless @member.checkout_balance.nil?
 
-      redirect_to users_root_url
+      redirect_to(users_root_url)
     else
       flash[:errors] = @member.errors.messages
 
       @member.educations.build(id: -1)
-      redirect_to status_path(token: params[:token])
+      redirect_to(status_path(token: params[:token]))
     end
   end
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -8,12 +8,12 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     # no confirmation token, redirect to login
     if @user.nil?
-      flash[:alert] = I18n.t 'devise.confirmations.no_token'
-      redirect_to :new_user_session
+      flash[:alert] = I18n.t('devise.confirmations.no_token')
+      redirect_to(:new_user_session)
       return
     end
 
-    render 'devise/confirmations/show'
+    render('devise/confirmations/show')
   end
 
   # This method is called once the user submits the form rendered in show
@@ -22,15 +22,15 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
     # no confirmation token
     if user.nil?
-      flash[:alert] = I18n.t 'devise.confirmations.no_token'
-      redirect_to :new_user_session
+      flash[:alert] = I18n.t('devise.confirmations.no_token')
+      redirect_to(:new_user_session)
       return
     end
 
     # require valid password to confirm email
     unless user.valid_password?(confirmation_params[:password])
-      flash[:alert] = I18n.t 'devise.failure.invalid_password'
-      redirect_to user_confirmation_path(confirmation_token: confirmation_params[:confirmation_token])
+      flash[:alert] = I18n.t('devise.failure.invalid_password')
+      redirect_to(user_confirmation_path(confirmation_token: confirmation_params[:confirmation_token]))
       return
     end
 
@@ -38,13 +38,13 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     # then update the email column for the member
     # finally, confirm the user with devise
     unless user.nil? || user.unconfirmed_email.nil? || user.admin?
-      MailchimpUpdateAddressJob.perform_later user.email, user.unconfirmed_email
+      MailchimpUpdateAddressJob.perform_later(user.email, user.unconfirmed_email)
       user.credentials.update_column(:email, user.unconfirmed_email)
       user.confirm
       user.confirmation_token = nil
     end
 
-    redirect_to :new_user_session, notice: I18n.t('devise.confirmations.confirmed')
+    redirect_to(:new_user_session, notice: I18n.t('devise.confirmations.confirmed'))
   end
 
   def confirmation_params

--- a/app/controllers/users/password_change_controller.rb
+++ b/app/controllers/users/password_change_controller.rb
@@ -7,7 +7,7 @@ class Users::PasswordChangeController < ApplicationController
   def edit
     @user = current_user
 
-    render 'user/password/edit'
+    render('user/password/edit')
   end
 
   def update
@@ -17,10 +17,10 @@ class Users::PasswordChangeController < ApplicationController
     # necessary
 
     if @user.update_with_password(user_params) && !params[:user][:password].empty?
-      bypass_sign_in @user, scope: :user
-      redirect_to root_path
+      bypass_sign_in(@user, scope: :user)
+      redirect_to(root_path)
     else
-      render 'user/password/edit'
+      render('user/password/edit')
     end
   end
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -2,13 +2,13 @@
 # account has not yet been confirmed.
 class Users::PasswordsController < Devise::PasswordsController
   def create
-    @user = User.find_by email: resource_params[:email]
+    @user = User.find_by(email: resource_params[:email])
 
     if @user && !@user.confirmed?
-      @user.resend_confirmation! :confirmation_instructions
+      @user.resend_confirmation!(:confirmation_instructions)
 
-      flash[:notice] = I18n.t 'devise.passwords.account_not_confirmed_resent'
-      redirect_to :new_user_session
+      flash[:notice] = I18n.t('devise.passwords.account_not_confirmed_resent')
+      redirect_to(:new_user_session)
       return
     end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,41 +7,41 @@ class Users::RegistrationsController < ActionController::Base
 
   def new
     @user = User.new
-    render 'devise/registrations/new'
+    render('devise/registrations/new')
   end
 
   def create
-    @user = User.find_by email: sign_up_params[:email]
+    @user = User.find_by(email: sign_up_params[:email])
     if @user && !@user.confirmed_at
-      @user.resend_confirmation! :confirmation_instructions
-      flash[:notice] = I18n.t 'devise.registrations.already_signed_up_unconfirmed'
+      @user.resend_confirmation!(:confirmation_instructions)
+      flash[:notice] = I18n.t('devise.registrations.already_signed_up_unconfirmed')
 
-      redirect_to :new_user_session
+      redirect_to(:new_user_session)
       return
     elsif @user&.confirmed_at
       @user.send_reset_password_instructions
-      flash[:notice] = I18n.t 'devise.passwords.send_instructions'
+      flash[:notice] = I18n.t('devise.passwords.send_instructions')
 
-      redirect_to :new_user_session
+      redirect_to(:new_user_session)
       return
     end
 
-    @user = User.new sign_up_params
-    @user.credentials = Member.find_by email: sign_up_params[:email]
+    @user = User.new(sign_up_params)
+    @user.credentials = Member.find_by(email: sign_up_params[:email])
 
     flash[:alert] = nil
 
     if @user.credentials.nil?
-      flash[:alert] = I18n.t :not_found_in_database, scope: 'devise.registrations'
-      render 'devise/registrations/new'
+      flash[:alert] = I18n.t(:not_found_in_database, scope: 'devise.registrations')
+      render('devise/registrations/new')
       return
     end
 
     if @user.save
-      flash[:notice] = I18n.t :signed_up_but_unconfirmed, scope: 'devise.registrations'
-      redirect_to :new_user_session
+      flash[:notice] = I18n.t(:signed_up_but_unconfirmed, scope: 'devise.registrations')
+      redirect_to(:new_user_session)
     else
-      render 'devise/registrations/new'
+      render('devise/registrations/new')
     end
   end
 
@@ -50,18 +50,18 @@ class Users::RegistrationsController < ActionController::Base
     @user = User.find_by(confirmation_token: params[:confirmation_token])
 
     if @user.nil?
-      flash[:alert] = I18n.t 'devise.passwords.no_token'
-      redirect_to :new_user_session
+      flash[:alert] = I18n.t('devise.passwords.no_token')
+      redirect_to(:new_user_session)
       return
     end
 
     if @user.confirmed?
-      flash[:notice] = "#{ @user.email } #{ I18n.t 'errors.messages.already_confirmed' }"
-      redirect_to :new_user_session
+      flash[:notice] = "#{ @user.email } #{ I18n.t('errors.messages.already_confirmed') }"
+      redirect_to(:new_user_session)
       return
     end
 
-    render 'devise/confirmations/edit'
+    render('devise/confirmations/edit')
   end
 
   # update newly chosen password
@@ -72,12 +72,12 @@ class Users::RegistrationsController < ActionController::Base
     if @user.save
       @user.confirm # confirm account
 
-      flash[:notice] = I18n.t :confirmed, scope: 'devise.confirmations'
-      redirect_to :new_user_session
+      flash[:notice] = I18n.t(:confirmed, scope: 'devise.confirmations')
+      redirect_to(:new_user_session)
       return
     end
 
-    render 'devise/confirmations/edit'
+    render('devise/confirmations/edit')
   end
 
   private
@@ -85,8 +85,8 @@ class Users::RegistrationsController < ActionController::Base
   def authenticate
     return if params[:confirmation_token].present?
 
-    flash[:alert] = I18n.t 'devise.passwords.no_token'
-    redirect_to :new_user_session
+    flash[:alert] = I18n.t('devise.passwords.no_token')
+    redirect_to(:new_user_session)
     return
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,6 +10,6 @@ class Users::SessionsController < Devise::SessionsController
     flash.delete(:notice) # remove "successfully signed in" message
   ensure
     # check if authentication succeeded, otherwise log failed attempt
-    logger.fatal "[#{ Time.zone.now }] #{ I18n.t('activerecord.errors.failed_login') }; #{ request.remote_ip }; #{ request.filtered_parameters['user']['email'] }" if current_user.nil?
+    logger.fatal("[#{ Time.zone.now }] #{ I18n.t('activerecord.errors.failed_login') }; #{ request.remote_ip }; #{ request.filtered_parameters['user']['email'] }") if current_user.nil?
   end
 end

--- a/app/jobs/mailchimp_job.rb
+++ b/app/jobs/mailchimp_job.rb
@@ -39,7 +39,7 @@ class MailchimpJob < ApplicationJob
     # set interests from mailchimp_interests (MMM/ALV/..) if interests not nil
     request[:interests] = Rails.configuration.mailchimp_interests.values.map { |i| { i => interests.include?(i) } }.reduce(&:merge) unless interests.nil?
 
-    logger.debug request.inspect
+    logger.debug(request.inspect)
 
     RestClient.put(
       "https://#{ ENV['MAILCHIMP_DATACENTER'] }.api.mailchimp.com/3.0/lists/#{ ENV['MAILCHIMP_LIST_ID'] }/members/#{ Digest::MD5.hexdigest(key.downcase) }",
@@ -64,8 +64,8 @@ class MailchimpJob < ApplicationJob
     Rails.cache.write("members/#{ member.id }/mailchimp/interests", request[:interests], expires_in: 30.days) unless interests.nil?
 
     tags = []
-    tags.push('alumni') unless member.educations.any? { |s| ['active'].include? s.status }
-    tags.push('gratie') if member.tags.any? { |t| ['merit', 'pardon'].include? t.name }
+    tags.push('alumni') unless member.educations.any? { |s| ['active'].include?(s.status) }
+    tags.push('gratie') if member.tags.any? { |t| ['merit', 'pardon'].include?(t.name) }
 
     RestClient.post(
       "https://#{ ENV['MAILCHIMP_DATACENTER'] }.api.mailchimp.com/3.0/lists/#{ ENV['MAILCHIMP_LIST_ID'] }/members/#{ Digest::MD5.hexdigest(key.downcase) }/tags",
@@ -74,8 +74,8 @@ class MailchimpJob < ApplicationJob
       'User-Agent': 'constipated-koala'
     )
   rescue RestClient::BadRequest => e
-    logger.debug JSON.parse(e.response.body)
+    logger.debug(JSON.parse(e.response.body))
   rescue RestClient::NotFound
-    logger.debug 'record not found'
+    logger.debug('record not found')
   end
 end

--- a/app/jobs/mailchimp_update_address_job.rb
+++ b/app/jobs/mailchimp_update_address_job.rb
@@ -10,7 +10,7 @@ class MailchimpUpdateAddressJob < ApplicationJob
       status_if_new: mailchimp_status
     }
 
-    logger.debug request.inspect
+    logger.debug(request.inspect)
 
     RestClient.put(
       "https://#{ ENV['MAILCHIMP_DATACENTER'] }.api.mailchimp.com/3.0/lists/#{ ENV['MAILCHIMP_LIST_ID'] }/members/#{ Digest::MD5.hexdigest(old_address.downcase) }",

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -25,14 +25,14 @@ class ApplicationMailer < ActionMailer::Base
   private
 
   def mail(recipient, sender, subject, html, text, attachment = nil)
-    raise ArgumentError if html.blank? && text.blank?
+    raise(ArgumentError) if html.blank? && text.blank?
 
     if ENV['MAILGUN_DOMAIN'].blank? || ENV['MAILGUN_TOKEN'].blank?
-      Rails.logger.error "mailgun credentials not send, cannot send email"
+      Rails.logger.error("mailgun credentials not send, cannot send email")
       return
     end
 
-    return RestClient.post "https://api:#{ ENV['MAILGUN_TOKEN'] }@api.mailgun.net/v3/#{ ENV['MAILGUN_DOMAIN'] }/messages",
+    return RestClient.post("https://api:#{ ENV['MAILGUN_TOKEN'] }@api.mailgun.net/v3/#{ ENV['MAILGUN_DOMAIN'] }/messages",
                            :from => sender || ::Devise.mailer_sender,
                            :to => recipient,
 
@@ -40,18 +40,18 @@ class ApplicationMailer < ActionMailer::Base
                            :html => html.to_str,
                            :text => text,
                            :attachment => attachment,
-                           'o:testmode' => Rails.env.development? ? 'true' : 'false'
+                           'o:testmode' => Rails.env.development? ? 'true' : 'false')
   end
 
   def mails(recipient, sender, subject, html, text, attachment = nil)
-    raise ArgumentError if (html.blank? && text.blank?) || recipient.blank?
+    raise(ArgumentError) if (html.blank? && text.blank?) || recipient.blank?
 
     if ENV['MAILGUN_DOMAIN'].blank? || ENV['MAILGUN_TOKEN'].blank?
-      Rails.logger.debug "mailgun credentials not send, cannot send email"
+      Rails.logger.debug("mailgun credentials not send, cannot send email")
       return
     end
 
-    return RestClient.post "https://api:#{ ENV['MAILGUN_TOKEN'] }@api.mailgun.net/v3/#{ ENV['MAILGUN_DOMAIN'] }/messages",
+    return RestClient.post("https://api:#{ ENV['MAILGUN_TOKEN'] }@api.mailgun.net/v3/#{ ENV['MAILGUN_DOMAIN'] }/messages",
                            :from => sender || ::Devise.mailer_sender,
                            :to => recipient.map { |email, item| "#{ item['name'] } <#{ email }>" },
 
@@ -61,6 +61,6 @@ class ApplicationMailer < ActionMailer::Base
                            :html => html.to_str,
                            :text => text,
                            :attachment => attachment,
-                           'o:testmode' => Rails.env.development? ? 'true' : 'false'
+                           'o:testmode' => Rails.env.development? ? 'true' : 'false')
   end
 end

--- a/app/mailers/mailings/checkout.rb
+++ b/app/mailers/mailings/checkout.rb
@@ -3,7 +3,7 @@ module Mailings
   #:nodoc:
   class Checkout < ApplicationMailer
     def confirmation_instructions(card, confirmation_url)
-      Rails.logger.debug confirmation_url if Rails.env.development?
+      Rails.logger.debug(confirmation_url) if Rails.env.development?
 
       subject_name = "#{ I18n.t('association_name') } | #{ I18n.t('mailings.checkout.subject') }"
 

--- a/app/mailers/mailings/devise.rb
+++ b/app/mailers/mailings/devise.rb
@@ -5,13 +5,13 @@ module Mailings
     include ::Devise::Controllers::UrlHelpers
 
     def confirmation_instructions(record, token, _opts = {})
-      Rails.logger.debug confirmation_url(record, confirmation_token: token) if Rails.env.development?
+      Rails.logger.debug(confirmation_url(record, confirmation_token: token)) if Rails.env.development?
 
-      html = render_to_string locals: {
-        name: record.credentials.name,
-        confirmation_url: confirmation_url(record, confirmation_token: token),
-        subject: "#{ I18n.t('association_name') } | #{ I18n.t('mailings.devise.confirmation_instructions.confirm_email') }"
-      }
+      html = render_to_string(locals: {
+                                name: record.credentials.name,
+                                confirmation_url: confirmation_url(record, confirmation_token: token),
+                                subject: "#{ I18n.t('association_name') } | #{ I18n.t('mailings.devise.confirmation_instructions.confirm_email') }"
+                              })
 
       text = <<~PLAINTEXT
         #{ I18n.t('mailings.greeting') } #{ record.credentials.name },
@@ -28,13 +28,13 @@ module Mailings
 
     def activation_instructions(record, token, _opts = {})
       url = new_member_confirmation_url(confirmation_token: token)
-      Rails.logger.debug url if Rails.env.development?
+      Rails.logger.debug(url) if Rails.env.development?
 
-      html = render_to_string locals: {
-        name: record.credentials.first_name,
-        activation_url: url,
-        subject: "#{ I18n.t('mailings.devise.activation_instructions.welcome') } | #{ I18n.t('mailings.devise.confirmation_instructions.activate_account') }"
-      }
+      html = render_to_string(locals: {
+                                name: record.credentials.first_name,
+                                activation_url: url,
+                                subject: "#{ I18n.t('mailings.devise.activation_instructions.welcome') } | #{ I18n.t('mailings.devise.confirmation_instructions.activate_account') }"
+                              })
 
       text = <<~MARKDOWN
         #{ I18n.t('mailings.greeting') } #{ record.credentials.first_name },
@@ -78,13 +78,13 @@ module Mailings
     end
 
     def reset_password_instructions(record, token, _opts = {})
-      Rails.logger.debug edit_password_url(record, reset_password_token: token) if Rails.env.development?
+      Rails.logger.debug(edit_password_url(record, reset_password_token: token)) if Rails.env.development?
 
-      html = render_to_string locals: {
-        name: record.credentials.name,
-        reset_url: edit_password_url(record, reset_password_token: token),
-        subject: "#{ I18n.t('association_name') } | #{ I18n.t('mailings.devise.reset_passwords_instructions.reset_password') }"
-      }
+      html = render_to_string(locals: {
+                                name: record.credentials.name,
+                                reset_url: edit_password_url(record, reset_password_token: token),
+                                subject: "#{ I18n.t('association_name') } | #{ I18n.t('mailings.devise.reset_passwords_instructions.reset_password') }"
+                              })
 
       text = <<~PLAINTEXT
         #{ I18n.t('mailings.greeting') } #{ record.credentials.name },
@@ -103,12 +103,12 @@ module Mailings
     def forced_confirm_email(record, current_user, _opts = {})
       Rails.logger.debug { "#{ record.user.unconfirmed_email } #{ I18n.t('mailings.removed') }" } if Rails.env.development?
 
-      html = render_to_string locals: {
-        name: record.name,
-        email: record.user.unconfirmed_email,
-        sendername: current_user.credentials.name,
-        subject: "#{ I18n.t('association_name') } | #{ I18n.t('mailings.devise.changed_instructions.changed_email') }"
-      }
+      html = render_to_string(locals: {
+                                name: record.name,
+                                email: record.user.unconfirmed_email,
+                                sendername: current_user.credentials.name,
+                                subject: "#{ I18n.t('association_name') } | #{ I18n.t('mailings.devise.changed_instructions.changed_email') }"
+                              })
 
       text = <<~PLAINTEXT
         #{ I18n.t('mailings.greeting') } #{ record.name },

--- a/app/mailers/mailings/participants.rb
+++ b/app/mailers/mailings/participants.rb
@@ -17,17 +17,17 @@ module Mailings
         }
       end
 
-      view = render_to_string inline: html, layout: 'mailer', locals: { subject: subject }
+      view = render_to_string(inline: html, layout: 'mailer', locals: { subject: subject })
       return mails(variables, sender, subject, view, text || strip_html(html.clone))
     end
 
     def enrolled(participant)
       member = participant.member
       activity = participant.activity
-      url = activity_url activity.id
+      url = activity_url(activity.id)
 
-      starts_at = I18n.l activity.start_date, format: :day_month
-      starts_at += ", #{ I18n.l activity.start_time, format: :short }" if activity.start_time
+      starts_at = I18n.l(activity.start_date, format: :day_month)
+      starts_at += ", #{ I18n.l(activity.start_time, format: :short) }" if activity.start_time
 
       price = activity.price
       price = if price > 0

--- a/app/mailers/mailings/payment_mailer.rb
+++ b/app/mailers/mailings/payment_mailer.rb
@@ -20,7 +20,7 @@ module Mailings
       total = prices.sum
 
       if total == 0
-        Rails.logger.error "Payment email was requested for #{ member.name }, but they don't have open payments"
+        Rails.logger.error("Payment email was requested for #{ member.name }, but they don't have open payments")
         return nil
       end
 

--- a/app/mailers/mailings/status.rb
+++ b/app/mailers/mailings/status.rb
@@ -14,7 +14,7 @@ module Mailings
         }
       end
 
-      html = render_to_string layout: 'mailer', locals: { subject: I18n.t('mailings.membership') }
+      html = render_to_string(layout: 'mailer', locals: { subject: I18n.t('mailings.membership') })
 
       text = <<~PLAINTEXT
         #{ I18n.t('mailings.greeting') } %recipient.first_name%,

--- a/app/mailers/mailings/studystatus.rb
+++ b/app/mailers/mailings/studystatus.rb
@@ -7,7 +7,7 @@ module Mailings
         # TODO: This does not have a body, currently recipients will be emtpy
       end
 
-      html = render_to_string inline: html, layout: 'mailer', locals: { subject: I18n.t('mailings.membership') }
+      html = render_to_string(inline: html, layout: 'mailer', locals: { subject: I18n.t('mailings.membership') })
 
       text = <<~PLAINTEXT
         #{ I18n.t('mailings.greeting') } %recipient.first_name%,

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -60,7 +60,7 @@ class Activity < ApplicationRecord
     # Remove the other illegal characters
     # Non-printable characters are ignored
     # source: https://www.sepaforcorporates.com/sepa-implementation/valid-xml-characters-sepa-payments/
-    return ascii.delete "!\"#$%&*;<=>@[\\]^_`{|}~"
+    return ascii.delete("!\"#$%&*;<=>@[\\]^_`{|}~")
   end
 
   def self.study_year(year)
@@ -132,7 +132,7 @@ class Activity < ApplicationRecord
   end
 
   def group
-    Group.find_by id: organized_by
+    Group.find_by(id: organized_by)
   end
 
   def currency(member)

--- a/app/models/checkout_product.rb
+++ b/app/models/checkout_product.rb
@@ -74,6 +74,6 @@ class CheckoutProduct < ApplicationRecord
   private
 
   def valid_image
-    errors.add :image, I18n.t('activerecord.errors.models.checkout_product.blank') unless image.present? || parent.present?
+    errors.add(:image, I18n.t('activerecord.errors.models.checkout_product.blank')) unless image.present? || parent.present?
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -198,7 +198,7 @@ class Member < ApplicationRecord
 
   before_update do
     if email_changed? && (User.exists?(email: email.downcase) || User.exists?(unconfirmed_email: email.downcase))
-      errors.add :email, I18n.t('activerecord.errors.models.member.attributes.email.taken')
+      errors.add(:email, I18n.t('activerecord.errors.models.member.attributes.email.taken'))
       raise ActiveRecord::Rollback
     end
 
@@ -363,7 +363,7 @@ class Member < ApplicationRecord
 
     export.compact
 
-    yield [export.to_json, Digest::MD5.hexdigest(export.to_s)] if block_given?
+    yield([export.to_json, Digest::MD5.hexdigest(export.to_s)]) if block_given?
   end
 
   def self.import(import, checksum); end
@@ -380,8 +380,8 @@ class Member < ApplicationRecord
   def before_destroy
     # check if all activities are paid
     unless unpaid_activities.empty?
-      errors.add :participants, I18n.t('activerecord.errors.models.member.attributes.participants.unpaid_activities')
-      raise ActiveRecord::Rollback
+      errors.add(:participants, I18n.t('activerecord.errors.models.member.attributes.participants.unpaid_activities'))
+      raise(ActiveRecord::Rollback)
     end
 
     # remove reservist
@@ -406,9 +406,9 @@ class Member < ApplicationRecord
       )
     end
   rescue RestClient::BadRequest => e
-    logger.debug JSON.parse(e.response.body)
+    logger.debug(JSON.parse(e.response.body))
   rescue RestClient::NotFound
-    logger.debug "Unable to delete Mailchimp user: user not found"
+    logger.debug("Unable to delete Mailchimp user: user not found")
 
     # create transaction for emptying checkout_balance
     CheckoutTransaction.create(checkout_balance: checkout_balance, price: -checkout_balance.balance, payment_method: 'deleted') if checkout_balance.present? && checkout_balance.balance != 0
@@ -417,7 +417,7 @@ class Member < ApplicationRecord
   # Perform an elfproef to verify the student_id
   def valid_student_id
     # on the intro website student_id is required
-    errors.add :student_id, I18n.t('activerecord.errors.models.member.attributes.student_id.invalid') if require_student_id && student_id.blank?
+    errors.add(:student_id, I18n.t('activerecord.errors.models.member.attributes.student_id.invalid')) if require_student_id && student_id.blank?
 
     # do not do the elfproef on a foreign student
     return if student_id =~ /\F\d{6}/

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -30,9 +30,9 @@ class Participant < ApplicationRecord
       prefix = "#{ activity.name } (#{ activity.id }) - "
       message = case i.action_name
                 when "update"
-                  I18n.t i.message, scope: [:activerecord, :attributes, :impression, i.impressionable_type.downcase, i.action_name]
+                  I18n.t(i.message, scope: [:activerecord, :attributes, :impression, i.impressionable_type.downcase, i.action_name])
                 else
-                  I18n.t i.action_name, scope: [:activerecord, :attributes, :impression, i.impressionable_type.downcase]
+                  I18n.t(i.action_name, scope: [:activerecord, :attributes, :impression, i.impressionable_type.downcase])
                 end
 
       newmessage = prefix + message

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -47,7 +47,7 @@ class Payment < ApplicationRecord
 
     case payment_type.to_sym
     when :ideal
-      http = ConstipatedKoala::Request.new ENV['MOLLIE_DOMAIN']
+      http = ConstipatedKoala::Request.new(ENV['MOLLIE_DOMAIN'])
       self.token = Digest::SHA256.hexdigest("#{ member.id }#{ Time.now.to_f }#{ redirect_uri }")
 
       request = http.post("/#{ ENV['MOLLIE_VERSION'] }/payments",
@@ -67,7 +67,7 @@ class Payment < ApplicationRecord
                           redirectUrl: Rails.application.routes.url_helpers.payment_redirect_url(token: token))
 
       request['Authorization'] = "Bearer #{ ENV['MOLLIE_TOKEN'] }"
-      response = http.send! request
+      response = http.send!(request)
 
       self.trxid = response.id
       self.payment_uri = response.links.paymentUrl
@@ -80,13 +80,13 @@ class Payment < ApplicationRecord
   def update_transaction!
     case payment_type.to_sym
     when :ideal
-      http = ConstipatedKoala::Request.new ENV['MOLLIE_DOMAIN']
+      http = ConstipatedKoala::Request.new(ENV['MOLLIE_DOMAIN'])
       @status = status
 
       request = http.get("/#{ ENV['MOLLIE_VERSION'] }/payments/#{ trxid }")
       request['Authorization'] = "Bearer #{ ENV['MOLLIE_TOKEN'] }"
 
-      response = http.send! request
+      response = http.send!(request)
 
       status_update(response.status)
 
@@ -151,12 +151,12 @@ class Payment < ApplicationRecord
     return [] if ENV['MOLLIE_TOKEN'].blank?
 
     Rails.cache.fetch('mollie_issuers', expires_in: 12.hours) do
-      http = ConstipatedKoala::Request.new ENV['MOLLIE_DOMAIN']
+      http = ConstipatedKoala::Request.new(ENV['MOLLIE_DOMAIN'])
 
       request = http.get("/#{ ENV['MOLLIE_VERSION'] }/issuers")
       request['Authorization'] = "Bearer #{ ENV['MOLLIE_TOKEN'] }"
 
-      response = http.send! request
+      response = http.send!(request)
       response.data.map { |issuer| [issuer.name, issuer.id] }
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,7 @@ class User < ApplicationRecord
   end
 
   def self.create_on_member_enrollment!(member)
-    password = Devise.friendly_token 128
+    password = Devise.friendly_token(128)
 
     user = User.new(
       credentials: member,

--- a/app/previewers/ghostscript_previewer.rb
+++ b/app/previewers/ghostscript_previewer.rb
@@ -12,17 +12,17 @@ class GhostscriptPreviewer < ActiveStorage::Previewer
     def ghostscript_exists?
       return @ghostscript_exists unless @ghostscript_exists.nil?
 
-      system ghostscript_path, '--version', out: File::NULL, err: File::NULL
+      system(ghostscript_path, '--version', out: File::NULL, err: File::NULL)
       @ghostscript_exists = $?.exitstatus == 0
     end
   end
 
   def preview
     download_blob_to_tempfile do |input|
-      Rails.logger.debug blob.filename.base
+      Rails.logger.debug(blob.filename.base)
 
-      draw_image_from_pdf input do |output|
-        yield io: output, filename: "#{ blob.filename.base }.png", content_type: "image/png"
+      draw_image_from_pdf(input) do |output|
+        yield(io: output, filename: "#{ blob.filename.base }.png", content_type: "image/png")
       end
     end
   end
@@ -33,9 +33,9 @@ class GhostscriptPreviewer < ActiveStorage::Previewer
     dst = Tempfile.new("#{ blob.filename.base }.png")
     dst.binmode
 
-    system self.class.ghostscript_path, '-dNOPAUSE', '-dSAFER', '-dBATCH', '-sDEVICE=pngalpha', '-r144', '-dUseCIEColor', "-sOutputFile=#{ dst.path }", input.path
+    system(self.class.ghostscript_path, '-dNOPAUSE', '-dSAFER', '-dBATCH', '-sDEVICE=pngalpha', '-r144', '-dUseCIEColor', "-sOutputFile=#{ dst.path }", input.path)
 
-    draw 'cat', dst.path, &block
-    File.delete dst
+    draw('cat', dst.path, &block)
+    File.delete(dst)
   end
 end

--- a/app/views/api/checkout/products.rabl
+++ b/app/views/api/checkout/products.rabl
@@ -3,5 +3,5 @@ collection @products
 attributes :id, :name, :category, :price
 
 node :image do |product|
-  "#{ ENV['KOALA_DOMAIN'] }#{ url_for product.url }" unless product.url.nil?
+  "#{ ENV['KOALA_DOMAIN'] }#{ url_for(product.url) }" unless product.url.nil?
 end

--- a/app/views/api/checkout/recent.rabl
+++ b/app/views/api/checkout/recent.rabl
@@ -3,5 +3,5 @@ collection @products
 attributes :id, :name, :category, :price
 
 node :image do |product|
-  "#{ ENV['KOALA_DOMAIN'] }#{ url_for product.url }" unless product.nil?
+  "#{ ENV['KOALA_DOMAIN'] }#{ url_for(product.url) }" unless product.nil?
 end

--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new(File.expand_path('..', __dir__))
 
 def system!(*args)
   system(*args) || abort("\n== Command #{ args } failed ==")

--- a/bin/spring
+++ b/bin/spring
@@ -10,7 +10,7 @@ unless defined?(Spring)
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
-    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    Gem.use_paths(Gem.dir, Bundler.bundle_path.to_s, *Gem.path)
     gem 'spring', spring.version
     require 'spring/binstub'
   end

--- a/bin/update
+++ b/bin/update
@@ -4,7 +4,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('..', __dir__)
+APP_ROOT = Pathname.new(File.expand_path('..', __dir__))
 
 def system!(*args)
   system(*args) || abort("\n== Command #{ args } failed ==")

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module ConstipatedKoala
   #:nodoc:
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults(5.1)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
@@ -32,12 +32,12 @@ module ConstipatedKoala
     # Set layout for controllers from gems, own controllers set the alternative layout
     # in the controller itself, for example Members::RegistrationsController
     config.to_prepare do
-      Devise::SessionsController.layout 'doorkeeper'
-      Devise::RegistrationsController.layout 'doorkeeper'
-      Devise::ConfirmationsController.layout 'doorkeeper'
-      Devise::UnlocksController.layout 'doorkeeper'
-      Devise::PasswordsController.layout 'doorkeeper'
-      Doorkeeper::AuthorizationsController.layout 'doorkeeper'
+      Devise::SessionsController.layout('doorkeeper')
+      Devise::RegistrationsController.layout('doorkeeper')
+      Devise::ConfirmationsController.layout('doorkeeper')
+      Devise::UnlocksController.layout('doorkeeper')
+      Devise::PasswordsController.layout('doorkeeper')
+      Doorkeeper::AuthorizationsController.layout('doorkeeper')
     end
 
     config.active_job.queue_adapter = :sidekiq
@@ -69,6 +69,6 @@ module ConstipatedKoala
     config.active_storage.service = :local
 
     # Generate translations.json
-    config.middleware.use I18n::JS::Middleware
+    config.middleware.use(I18n::JS::Middleware)
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,7 @@
 # Load the Rails application.
 require_relative 'application'
 
-Rails.logger = Logger.new File.open(ENV['LOG_DIRECTORY'], 'a') if ENV['LOG_DIRECTORY'].present?
+Rails.logger = Logger.new(File.open(ENV['LOG_DIRECTORY'], 'a')) if ENV['LOG_DIRECTORY'].present?
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/lib/request.rb
+++ b/lib/request.rb
@@ -9,7 +9,7 @@ module ConstipatedKoala
   #:nodoc:
   class Request
     def initialize(domain)
-      @uri = URI.parse domain
+      @uri = URI.parse(domain)
 
       @client = Net::HTTP.new(@uri.host, @uri.port)
       @client.set_debug_output($stdout) unless Rails.env.production?
@@ -48,7 +48,7 @@ module ConstipatedKoala
         response = @client.request(request)
       rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
              Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
-        raise SocketError e.message
+        raise(SocketError(e.message))
       end
 
       case response.code.to_i
@@ -57,8 +57,8 @@ module ConstipatedKoala
       when 204
         {}
       else
-        Rails.logger.debug @client.inspect
-        raise ArgumentError, response.code.to_i
+        Rails.logger.debug(@client.inspect)
+        raise(ArgumentError, response.code.to_i)
       end
     end
   end

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -16,7 +16,7 @@ namespace :admin do
 
   desc 'Delete a normal user, that is it\'s login access'
   task :remove, [:email] => :environment do |_, args|
-    user = User.find_by email: args[:email]
+    user = User.find_by(email: args[:email])
 
     if user.nil?
       puts "#{ args[:email] } not found"
@@ -31,7 +31,7 @@ namespace :admin do
 
   desc 'Delete an admin account and user'
   task :delete, [:email] => :environment do |_, args|
-    user = User.find_by email: args[:email]
+    user = User.find_by(email: args[:email])
 
     if user.nil? || !user.admin?
       puts "#{ args[:email] } not found"

--- a/lib/tasks/doorkeeper.rake
+++ b/lib/tasks/doorkeeper.rake
@@ -21,7 +21,7 @@ namespace :doorkeeper do
 
   desc 'Delete an application using the application id.'
   task :delete, [:application] => :environment do |_, args|
-    app = Doorkeeper::Application.find_by! uid: args[:application]
+    app = Doorkeeper::Application.find_by!(uid: args[:application])
     app.destroy
   end
 end

--- a/test/controllers/api/activities_controller_test.rb
+++ b/test/controllers/api/activities_controller_test.rb
@@ -9,7 +9,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     get '/api/activities'
     assert_response :success
 
-    data = JSON.parse @response.body # @response is set automagically on get
+    data = JSON.parse(@response.body) # @response is set automagically on get
 
     # Assert that we see all activities we should
     should_see = Activity.where(is_viewable: true).to_a


### PR DESCRIPTION
This is an old pet peeve of mine: Ruby allows functions to be called without parentheses.
In my opinion, this just makes the code less readable, especially for beginners.
All changes are made my `rubocop --auto-correct`, which should be completely safe.
The exception to this rule is a somewhat unrelated change in  `app/controllers/public/status_controller.rb`, where 'not include' was replaced by 'exclude' by `rubocop --auto-correct-all`.
I double-checked, and this should be safe too.