### PR TITLE
allow non-sparelist enrolls to filterless activities

### DIFF
--- a/app/controllers/members/participants_controller.rb
+++ b/app/controllers/members/participants_controller.rb
@@ -143,7 +143,7 @@ class Members::ParticipantsController < ApplicationController
 
   # Helper functions to decrease the complexity of create
   def participant_filter_check?
-    participant_freshman_check? || participant_sophomore_check? || participant_senior_check? || participant_master_check?
+    !@activity.filters? || participant_freshman_check? || participant_sophomore_check? || participant_senior_check? || participant_master_check?
   end
 
   def participant_freshman_check?


### PR DESCRIPTION
This solves a bug introduced in #869
It was not possible to enroll without being placed on the spare list for activities without filters.
This has been fixed in this PR.