### PR TITLE
Update the definition of defaulters to align with the payable attribute

### DIFF
--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -13,8 +13,6 @@ class Admin::HomeController < ApplicationController
 
     @unpayed = Participant.where(reservist: false, paid: false).joins(:activity).where('activities.start_date < NOW()').sum(:price) + Participant.where(reservist: false, paid: false, price: nil).joins(:activity).where('activities.start_date < NOW() AND activities.price IS NOT NULL').sum('activities.price')
 
-    @defaulters = Participant.where(reservist: false, paid: false).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum(:price).merge( \
-      Participant.where(reservist: false, paid: false, price: nil).joins(:activity, :member).where('activities.start_date < NOW()').group(:member_id).sum('activities.price ')
-    ) { |_, sum_a, sum_b| sum_a + sum_b }.sort_by { |_, sum| -sum }.map { |k, v| [Member.where(id: k).select(:id, :first_name, :infix, :last_name).first, v] }.take(12).delete_if { |_, v| v == 0 }
+    @defaulters = Member.debtors.sort_by { |debtor| -debtor.total_outstanding_payments }.take(12)
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -119,6 +119,10 @@ class Member < ApplicationRecord
     write_attribute(:email, email.downcase) if user.nil?
   end
 
+  def total_outstanding_payments
+    return unpaid_activities.map { |activity| participant_by_activity(activity).currency }.sum
+  end
+
   # Returns the participant that belongs to this member and the given activity.
   # Do not pass an activity to this method that this member is not a participant of!
   def participant_by_activity(activity)

--- a/app/views/admin/home/index.html.haml
+++ b/app/views/admin/home/index.html.haml
@@ -136,4 +136,4 @@
               - @defaulters.each do |member, amount|
                 %tr
                   %td= link_to member.name, member
-                  %td= number_to_currency( amount, :unit => '€' )
+                  %td= number_to_currency( member.total_outstanding_payments, :unit => '€' )


### PR DESCRIPTION
This makes the definition of defaulters use the payable attribute.
This code is a lot more readable too.