### PR TITLE
GPDR Mail

### DIFF
--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -63,6 +63,7 @@ class Members::HomeController < ApplicationController
     @member = Member.find(current_user.credentials_id)
 
     if @member.update(member_post_params.except('mailchimp_interests'))
+      puts (ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?)
       unless ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?
         MailchimpJob.perform_later(@member.email, @member, (member_post_params[:mailchimp_interests].select do |_, val|
                                                               val == '1'

--- a/app/controllers/members/home_controller.rb
+++ b/app/controllers/members/home_controller.rb
@@ -63,7 +63,6 @@ class Members::HomeController < ApplicationController
     @member = Member.find(current_user.credentials_id)
 
     if @member.update(member_post_params.except('mailchimp_interests'))
-      puts (ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?)
       unless ENV['MAILCHIMP_DATACENTER'].blank? || member_post_params[:mailchimp_interests].nil?
         MailchimpJob.perform_later(@member.email, @member, (member_post_params[:mailchimp_interests].select do |_, val|
                                                               val == '1'

--- a/app/controllers/public/status_controller.rb
+++ b/app/controllers/public/status_controller.rb
@@ -18,7 +18,8 @@ class Public::StatusController < PublicController
       impressionist(@member)
       # Update mailchimp interests since member became alumni / is alumni.
       unless ENV['MAILCHIMP_DATACENTER'].blank? && !@member.is_active?
-        MailchimpJob.perform_later(@member.email, @member, member_post_params[:mailchimp_interests].nil? ? [] : member_post_params[:mailchimp_interests].compact_blank)
+        MailchimpJob.perform_later(@member.email, @member,
+                                   member_post_params[:mailchimp_interests].nil? ? [] : member_post_params[:mailchimp_interests].compact_blank)
       end
       if @member.educations.none?(&:active?) && %w[yearly indefinite].exclude?(@member.consent)
         @member.errors.add(:base, I18n.t('activerecord.errors.no_consent'))
@@ -77,6 +78,7 @@ class Public::StatusController < PublicController
     params[:member][:consent] = 'indefinite' if params[:indefinite] == '1'
     params[:member][:mailchimp_interests] = params[:mailchimp_interests].keys if params[:mailchimp_interests]
 
-    params.require(:member).permit(:consent, educations_attributes: [:id, :study_id, :status], :mailchimp_interests => [])
+    params.require(:member).permit(:consent, educations_attributes: [:id, :study_id, :status],
+                                             mailchimp_interests: [])
   end
 end

--- a/app/controllers/public/status_controller.rb
+++ b/app/controllers/public/status_controller.rb
@@ -17,7 +17,8 @@ class Public::StatusController < PublicController
     if @member.update(member_post_params)
       impressionist(@member)
 
-      unless ENV['MAILCHIMP_DATACENTER'].blank?
+      # Update mailchimp interests since member became inactive / is inactive.
+      unless ENV['MAILCHIMP_DATACENTER'].blank? && !@member.is_active?
         MailchimpJob.perform_later(@member.email, @member, member_post_params[:mailchimp_interests].nil? ? [] : member_post_params[:mailchimp_interests].compact_blank)
       end
       if @member.educations.none?(&:active?) && %w[yearly indefinite].exclude?(@member.consent)

--- a/app/jobs/mailchimp_job.rb
+++ b/app/jobs/mailchimp_job.rb
@@ -38,7 +38,8 @@ class MailchimpJob < ApplicationJob
 
     # set interests from mailchimp_interests (MMM/ALV/..) if interests not nil
     unless interests.nil?
-      request[:interests] = (Rails.configuration.mailchimp_interests.values + Rails.configuration.mailchimp_interests_alumni.values).map do |i|
+      request[:interests] = (Rails.configuration.mailchimp_interests.values +
+      Rails.configuration.mailchimp_interests_alumni.values).map do |i|
         { i => interests.include?(i) }
       end.reduce(&:merge)
     end

--- a/app/jobs/mailchimp_job.rb
+++ b/app/jobs/mailchimp_job.rb
@@ -38,7 +38,7 @@ class MailchimpJob < ApplicationJob
 
     # set interests from mailchimp_interests (MMM/ALV/..) if interests not nil
     unless interests.nil?
-      request[:interests] = Rails.configuration.mailchimp_interests.values.map do |i|
+      request[:interests] = (Rails.configuration.mailchimp_interests.values + Rails.configuration.mailchimp_interests_alumni.values).map do |i|
         { i => interests.include?(i) }
       end.reduce(&:merge)
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -126,8 +126,10 @@ class Member < ApplicationRecord
   def is_active?
     return true if educations.any? { |s| ['active'].include?(s.status) }
     return true if tags.any? { |t| ['merit', 'pardon'].include?(t.name) }
+
     false
   end
+
   # Returns the participant that belongs to this member and the given activity.
   # Do not pass an activity to this method that this member is not a participant of!
   def participant_by_activity(activity)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -123,6 +123,11 @@ class Member < ApplicationRecord
     return unpaid_activities.map { |activity| participant_by_activity(activity).currency }.sum
   end
 
+  def is_active?
+    return true if educations.any? { |s| ['active'].include?(s.status) }
+    return true if tags.any? { |t| ['merit', 'pardon'].include?(t.name) }
+    false
+  end
   # Returns the participant that belongs to this member and the given activity.
   # Do not pass an activity to this method that this member is not a participant of!
   def participant_by_activity(activity)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -123,7 +123,7 @@ class Member < ApplicationRecord
     return unpaid_activities.map { |activity| participant_by_activity(activity).currency }.sum
   end
 
-  def is_active?
+  def active?
     return true if educations.any? { |s| ['active'].include?(s.status) }
     return true if tags.any? { |t| ['merit', 'pardon'].include?(t.name) }
 

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -103,7 +103,7 @@
             = I18n.t(:mailinglists, scope: 'activerecord.annotations.member')
           .card-body
             .form-group
-              - if !@member.mailchimp_interests.nil? && @member.is_active?
+              - if !@member.mailchimp_interests.nil? && @member.active?
                 - Rails.configuration.mailchimp_interests.each do |name, key|
                   .row
                     .col-md-12

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -103,8 +103,16 @@
             = I18n.t(:mailinglists, scope: 'activerecord.annotations.member')
           .card-body
             .form-group
-              - if !@member.mailchimp_interests.nil?
+              - if !@member.mailchimp_interests.nil? && @member.is_active?
                 - Rails.configuration.mailchimp_interests.each do |name, key|
+                  .row
+                    .col-md-12
+                      %label.ui-checkbox
+                        = f.check_box "mailchimp_interests[#{key}]", :checked => @member.mailchimp_interests[key]
+                        %span= I18n.t("#{name}.name", scope: 'activerecord.annotations.member')
+                        .callout.callout-info= I18n.t("#{name}.description", scope: 'activerecord.annotations.member')
+              - if !@member.is_active?
+                - Rails.configuration.mailchimp_interests_alumni.each do |name, key|
                   .row
                     .col-md-12
                       %label.ui-checkbox

--- a/app/views/members/home/edit.html.haml
+++ b/app/views/members/home/edit.html.haml
@@ -111,7 +111,7 @@
                         = f.check_box "mailchimp_interests[#{key}]", :checked => @member.mailchimp_interests[key]
                         %span= I18n.t("#{name}.name", scope: 'activerecord.annotations.member')
                         .callout.callout-info= I18n.t("#{name}.description", scope: 'activerecord.annotations.member')
-              - if !@member.is_active?
+              - if !@member.respond_to?(:alumni)
                 - Rails.configuration.mailchimp_interests_alumni.each do |name, key|
                   .row
                     .col-md-12

--- a/app/views/public/status/edit.html.haml
+++ b/app/views/public/status/edit.html.haml
@@ -69,6 +69,13 @@
             %label.ui-checkbox
               = check_box_tag 'indefinite'
               %span= I18n.t :indefinite_consent, scope: @scope
+          - Rails.configuration.mailchimp_interests_alumni.each do |name, key|
+            .row
+              .col-md-12
+                %label.ui-checkbox
+                  = check_box_tag "mailchimp_interests[#{key}]", :checked => @member.mailchimp_interests[key]
+                  %span= I18n.t("#{name}.name", scope: 'activerecord.annotations.member')
+                  .callout.callout-info= I18n.t("#{name}.description", scope: 'activerecord.annotations.member')
 
     %hr
 

--- a/app/views/public/status/edit.html.haml
+++ b/app/views/public/status/edit.html.haml
@@ -28,7 +28,7 @@
 
   %hr
 
-  = form_for :member, :url => status_path(:token => @token.token), :class => 'form-validation', :remote => true, :authenticity_token => true do |f|
+  = form_for :member, :url => status_path(:token => @token.token), :class => 'form-validation', :authenticity_token => true do |f|
     .row
       .col-12.studies
         - @member.educations.each do |education|
@@ -70,12 +70,11 @@
               = check_box_tag 'indefinite'
               %span= I18n.t :indefinite_consent, scope: @scope
           - Rails.configuration.mailchimp_interests_alumni.each do |name, key|
-            .row
-              .col-md-12
-                %label.ui-checkbox
-                  = check_box_tag "mailchimp_interests[#{key}]", "", @member.mailchimp_interests[key]
-                  %span= I18n.t("#{name}.title_gpdr", scope: 'activerecord.annotations.member')
-                  .callout.callout-info= I18n.t("#{name}.description_gpdr", scope: 'activerecord.annotations.member')
+            %dt= I18n.t("#{name}.title_gpdr", scope: 'activerecord.annotations.member')
+            %dd
+              %label.ui-checkbox
+                = check_box_tag "mailchimp_interests[#{key}]", "", @member.mailchimp_interests[key]
+                %span= I18n.t("#{name}.description_gpdr", scope: 'activerecord.annotations.member')
 
     %hr
 

--- a/app/views/public/status/edit.html.haml
+++ b/app/views/public/status/edit.html.haml
@@ -73,7 +73,7 @@
             .row
               .col-md-12
                 %label.ui-checkbox
-                  = check_box_tag "mailchimp_interests[#{key}]", :checked => @member.mailchimp_interests[key]
+                  = check_box_tag "mailchimp_interests[#{key}]", "", @member.mailchimp_interests[key]
                   %span= I18n.t("#{name}.name", scope: 'activerecord.annotations.member')
                   .callout.callout-info= I18n.t("#{name}.description", scope: 'activerecord.annotations.member')
 

--- a/app/views/public/status/edit.html.haml
+++ b/app/views/public/status/edit.html.haml
@@ -74,8 +74,8 @@
               .col-md-12
                 %label.ui-checkbox
                   = check_box_tag "mailchimp_interests[#{key}]", "", @member.mailchimp_interests[key]
-                  %span= I18n.t("#{name}.name", scope: 'activerecord.annotations.member')
-                  .callout.callout-info= I18n.t("#{name}.description", scope: 'activerecord.annotations.member')
+                  %span= I18n.t("#{name}.title_gpdr", scope: 'activerecord.annotations.member')
+                  .callout.callout-info= I18n.t("#{name}.description_gpdr", scope: 'activerecord.annotations.member')
 
     %hr
 

--- a/bin/get_mailchimp_interest_ids.sh
+++ b/bin/get_mailchimp_interest_ids.sh
@@ -18,8 +18,8 @@ echo "Interest IDs:"
 echo 
 
 # Get lists with curl, use jq to find the list id
-listid=`curl -sS "https://us20.api.mailchimp.com/3.0/lists" --user "yeet:$token" | jq -r '.lists[0].id'`
+listid=`curl -sS "https://us5.api.mailchimp.com/3.0/lists" --user "yeet:$token" | jq -r '.lists[2].id'` # When running this script i had to use idx 2
 # Get the interest categories with curl, use jq to find the category id
-catid=`curl -sS "https://us20.api.mailchimp.com/3.0/lists/{$listid}/interest-categories" --user "yeet:$token" | jq -r '.categories[0].id'`
+catid=`curl -sS "https://us5.api.mailchimp.com/3.0/lists/{$listid}/interest-categories" --user "yeet:$token" | jq -r '.categories[0].id'`
 # Get the interests with curl, use jq to find their names and IDs
-curl -sS "https://us20.api.mailchimp.com/3.0/lists/{$listid}/interest-categories/{$catid}/interests" --user "yeet:$token" | jq -r '.interests[] | .name, .id'
+curl -sS "https://us5.api.mailchimp.com/3.0/lists/{$listid}/interest-categories/{$catid}/interests" --user "yeet:$token" | jq -r '.interests[] | .name, .id'

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,9 @@ module ConstipatedKoala
       teacher: ENV['MAILCHIMP_TEACHER_ID']
     }
 
+    config.mailchimp_interests_alumni = {
+      alumni: ENV['MAILCHIMP_ALUMNI_ID']
+    }
     config.mailchimp_tags = ["gratie", "alumni"]
 
     config.action_dispatch.rescue_responses = {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,7 @@ en:
     annotations:
       member:
         alv:
-          description: Get a few times per year an invitation for the general assemblies in your mailbox.
+          description: By registering for this list, you will receive an invitation to the General Member Meeting along with the documents in your mailbox a few times a year.
           name: General assembly
         business:
           description: When you sign up for this list you will occasionally receive emails from one of the sponsors of Sticky. This mails concern invitations for their events or career options. This mailing is sent by Sticky, your emailadres will never be shared with external companies.
@@ -22,6 +22,11 @@ en:
         teacher:
           description: When you sign up for this list you will receive emails a few times a year with stories from teachers. This provides a new way to get to know more about your teachers.
           name: Teacher mailing
+        alumni:
+          description: By subscribing to this list you will occasionally receive an email from Sticky about alumni-related activities, such as an invitation to an alumni barbecue.
+          name: Alumni mailing
+          description_gpdr: I give permission to keep my data and also sign up for the alumni mailing, until I indicate otherwise. This can also be adjusted through Koala.
+          title_gpdr: We may keep your data for the alumni mailing.
     attributes:
       activity:
         comments: Comments (private)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,11 @@ en:
   activerecord:
     annotations:
       member:
+        alumni:
+          description: By subscribing to this list you will occasionally receive an email from Sticky about alumni-related activities, such as an invitation to an alumni barbecue.
+          description_gpdr: I give permission to keep my data and also sign up for the alumni mailing, until I indicate otherwise. This can also be adjusted through Koala.
+          name: Alumni mailing
+          title_gpdr: We may keep your data for the alumni mailing.
         alv:
           description: By registering for this list, you will receive an invitation to the General Member Meeting along with the documents in your mailbox a few times a year.
           name: General assembly
@@ -22,11 +27,6 @@ en:
         teacher:
           description: When you sign up for this list you will receive emails a few times a year with stories from teachers. This provides a new way to get to know more about your teachers.
           name: Teacher mailing
-        alumni:
-          description: By subscribing to this list you will occasionally receive an email from Sticky about alumni-related activities, such as an invitation to an alumni barbecue.
-          name: Alumni mailing
-          description_gpdr: I give permission to keep my data and also sign up for the alumni mailing, until I indicate otherwise. This can also be adjusted through Koala.
-          title_gpdr: We may keep your data for the alumni mailing.
     attributes:
       activity:
         comments: Comments (private)

--- a/config/locales/mailings.en.yml
+++ b/config/locales/mailings.en.yml
@@ -46,6 +46,7 @@ en:
         reset_password: Reset password
     gdpr:
       consent: Manage personal information
+      enrolled: You are currently registered with Study Association Sticky.
       gdpr_instructions: You are a member of Study association Sticky, because you are studying or have studied at University Utrecht. At Sticky we want to know what we may do with your data after your membership has ended. At the link below you can indicate what our permissions are. We also like to keep your data up to date so it is also possible to correct any errors by following the same link.
     greeting: Hi
     membership: Membership Study association Sticky

--- a/config/locales/mailings.nl.yml
+++ b/config/locales/mailings.nl.yml
@@ -46,7 +46,8 @@ nl:
         reset_password: Reset wachtwoord
     gdpr:
       consent: Persoonsgegevens beheren
-      gdpr_instructions: Je staat ingeschreven bij Studievereniging Sticky omdat je een studie doet of hebt gedaan bij de Universiteit Utrecht. Als vereniging willen we graag weten wat we met jouw gegevens mogen doen, nu je lidmaatschap is verlopen. Dit kan je aangeven via onderstaande link. Verder vinden we het fijn als de gegevens kloppen, dus dat kan je daar ook aanpassen, indien dat nodig is.
+      enrolled: Op het moment sta je bij Studievereniging Sticky ingeschreven.
+      gdpr_instructions: Je staat momenteel ingeschreven bij Studievereniging Sticky omdat je een studie doet of hebt gedaan bij de Universiteit Utrecht, of op een andere manier betrokken was met de vereniging. In ons systeem sta je aangegeven als eerste-, derde-, of vijfdejaars (of meer).<br/> <br/>Het kan zo zijn dat je al klaar bent met studeren, wat zou betekenen dat je lidmaatschap is verlopen. In dit geval zouden we graag weten wat we met jouw gegevens mogen doen, dit kan je aangeven via onderstaande link. Daarnaast vinden we het fijn als je gegevens nog kloppen. Je gegevens kan je via dezelfde link aanpassen, indien dat nodig is. <br/><br/>Als laatste willen we vragen of je, als je nu een alumni bent, je wilt aanmelden voor de alumni mailing lijst. Als je gewoon nog aan het studeren bent, hoeft dit natuurlijk niet.
     greeting: Hoi
     membership: Lidmaatschap Studievereniging Sticky
     participants:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -4,7 +4,7 @@ nl:
     annotations:
       member:
         alv:
-          description: Krijg een paar keer per jaar een uitnodiging en de stukken voor de leden vergaderingen in je mailbox.
+          description: Door je voor deze lijst aan te melden krijg je een paar keer per jaar een uitnodiging voor de ALV samen met de stukken in je mailbox.
           name: Algemene Leden Vergaderingen
         business:
           description: Door je voor deze lijst aan te melden zul je zo nu en dan een mail van één van de sponsoren van Sticky ontvangen. Deze mails zijn vaak uitnodigingen voor hun events, of brengen je op de hoogte van de mogelijkheden die zij studenten bieden zoals (bij)banen, stages, en scriptiebegeleiding. Deze mailing wordt door Sticky zelf aan haar leden verstuurd, bedrijven krijgen dus nooit jouw e-mailadres van ons voor deze mails.
@@ -22,6 +22,11 @@ nl:
         teacher:
           description: Door je voor deze lijst aan te melden zal je een paar keer per jaar mailtjes krijgen met allemaal verhalen van docenten. Zo kan je docenten leren kennen op een nieuwe manier.
           name: Docentenmailing
+        alumni:
+          description: Door je voor deze lijst aan te melden zul je sporadisch een mail van Sticky ontvangen over alumni-gerelateerde activiteiten, zoals een uitnodiging voor een alumni barbecue.
+          name: Alumnimailing
+          description_gpdr: Ik geef toestemming om mijn gegevens te bewaren en meld me ook aan voor de alumnimailing, totdat ik anders aangeef. Dit kan ook aangepast worden via Koala.
+          title_gpdr: Wij mogen je gegevens bewaren voor de alumnimailing. 
     attributes:
       activity:
         comments: Opmerkingen (privé)

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -3,6 +3,11 @@ nl:
   activerecord:
     annotations:
       member:
+        alumni:
+          description: Door je voor deze lijst aan te melden zul je sporadisch een mail van Sticky ontvangen over alumni-gerelateerde activiteiten, zoals een uitnodiging voor een alumni barbecue.
+          description_gpdr: Ik geef toestemming om mijn gegevens te bewaren en meld me ook aan voor de alumnimailing, totdat ik anders aangeef. Dit kan ook aangepast worden via Koala.
+          name: Alumnimailing
+          title_gpdr: Wij mogen je gegevens bewaren voor de alumnimailing.
         alv:
           description: Door je voor deze lijst aan te melden krijg je een paar keer per jaar een uitnodiging voor de ALV samen met de stukken in je mailbox.
           name: Algemene Leden Vergaderingen
@@ -22,11 +27,6 @@ nl:
         teacher:
           description: Door je voor deze lijst aan te melden zal je een paar keer per jaar mailtjes krijgen met allemaal verhalen van docenten. Zo kan je docenten leren kennen op een nieuwe manier.
           name: Docentenmailing
-        alumni:
-          description: Door je voor deze lijst aan te melden zul je sporadisch een mail van Sticky ontvangen over alumni-gerelateerde activiteiten, zoals een uitnodiging voor een alumni barbecue.
-          name: Alumnimailing
-          description_gpdr: Ik geef toestemming om mijn gegevens te bewaren en meld me ook aan voor de alumnimailing, totdat ik anders aangeef. Dit kan ook aangepast worden via Koala.
-          title_gpdr: Wij mogen je gegevens bewaren voor de alumnimailing. 
     attributes:
       activity:
         comments: Opmerkingen (privé)


### PR DESCRIPTION
Was checking if the system for GPDR was going to run correctly this summer. Everything seems functional except for the fact that mailchimp does net get updated when changing their status. To fix this we should just run a mailchimp job and they would receive their alumni tag. Additionally it would probably be preferable to also add an alumni list so even though alumnis keep their account they can easily toggle if they want to receive alumni mails.