### PR TITLE
Prepare oauth for undead mongoose

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,6 +11,7 @@ Doorkeeper::OAuth::TokenResponse.class_eval do
 
     # added some information about the user that is loggedin
     user = User.find_by_id(token.resource_owner_id)
+    # don't use this! User info should be obtained through claims!
     response = response.merge(user.as_json.reject { |k, _v| k == "id" }) unless user.nil?
     response['id_token'] = user.email unless user.nil?
 

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -38,6 +38,10 @@ Doorkeeper::OpenidConnect.configure do
     claim :email, response: [:id_token, :user_info] do |resource_owner|
       resource_owner.email
     end
+
+    claim :is_admin, response: [:id_token, :user_info] do |resource_owner|
+      resource_owner.admin?
+    end
   end
   # Example claims:
   # claims do


### PR DESCRIPTION
Adds an is_admin claim that lets undead mongoose know whether it should create a superuser or not.