### PR TITLE
Reservist sign-out button color change

### DIFF
--- a/app/javascript/src/members/activities/activity.js
+++ b/app/javascript/src/members/activities/activity.js
@@ -436,11 +436,11 @@ var Enrollment_stati = {
     I18n.t("members.activities.actions.unenroll")
   ),
   reservist: new Enrollment_status(
-    "btn-warning",
+    "btn-reservistSignout",
     I18n.t("members.activities.actions.reservist_unenroll")
   ),
   reservistable: new Enrollment_status(
-    "btn-warning",
+    "btn-reservistSignup",
     I18n.t("members.activities.actions.reservist_enroll")
   ),
 };

--- a/app/views/members/activities/partials/_view.html.haml
+++ b/app/views/members/activities/partials/_view.html.haml
@@ -98,18 +98,18 @@
         %button.btn.btn-info.update-enrollment.col-9.col-sm-6{ :class => ('d-none' unless (@member.confirmed_activities.ids.include? activity.id) || (@member.reservist_activities.ids.include? activity.id))}
           = I18n.t("members.activities.actions.update_info")
       - if activity.open?
-        - if @member.confirmed_activities.ids.include? activity.id
+        - if @member.confirmed_activities.ids.include? activity.id                  # confirmed sign-in
           - button_text = I18n.t("members.activities.actions.unenroll")
           - button_class = 'btn-danger col-12 col-sm-6'
-          - if !activity.unenroll_date.nil? && activity.unenroll_date < Date.today
+          - if !activity.unenroll_date.nil? && activity.unenroll_date < Date.today  # confirmed sign-in -- past sign-out deadline
             - button_class += ' disabled'
-        - elsif @member.reservist_activities.ids.include? activity.id
-          - button_text = I18n.t("members.activities.actions.reservist_unenroll")
-          - button_class = 'btn-warning col-12 col-sm-6'
-        - elsif activity.participant_limit != nil && activity.participant_limit <= activity.participants.count
+        - elsif @member.reservist_activities.ids.include? activity.id               # signed in as reservist (time is before sign-out deadline so can sign out)
+          - button_text = I18n.t("members.activities.actions.reservist_unenroll")   # there is no case where you can sign up as reservist after sign-out deadline, as of writing
+          - button_class = 'btn-reservistSignout col-12 col-sm-6'
+        - elsif activity.participant_limit != nil && activity.participant_limit <= activity.participants.count # not signed in -- but can do so as reservist only
           - button_text = I18n.t("members.activities.actions.reservist_enroll")
-          - button_class = 'btn-warning col-12 col-sm-6'
-        - else
+          - button_class = 'btn-reservistSignup col-12 col-sm-6'
+        - else                                                                      # not signed in -- and but can do so, not as reservist
           - button_text = I18n.t("members.activities.actions.enroll")
           - button_class = 'btn-success col-12 col-sm-6'
         %button.btn.enrollment{ :class => button_class}

--- a/vendor/assets/stylesheets/yeti.css.scss
+++ b/vendor/assets/stylesheets/yeti.css.scss
@@ -31,6 +31,7 @@
   --success: #43ac6a;
   --info: #5bc0de;
   --warning: #E99002;
+  --warning-accent: #e96a02;
   --danger: #F04124;
   --light: #eee;
   --dark: #222;
@@ -2751,6 +2752,18 @@ fieldset:disabled a.btn {
   color: #fff;
   background-color: #E99002;
   border-color: #E99002;
+}
+
+.btn-reservistSignup {
+  color: #fff;
+  background-color: #E99002;
+  border-color: #E99002;
+}
+
+.btn-reservistSignout {
+  color: #fff;
+  background-color: #e96a02;
+  border-color: #e96a02;
 }
 
 .btn-warning:hover {


### PR DESCRIPTION
Now, the sign-out color is a more darker (scarier) orange so that the user can easily distinguish signed-in activities from others.
Previously, it was the same default orange used as a warning color.

This idea is brought to you by Jack.