### PR TITLE
Activy URL is now displayed in the appointment description

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -365,7 +365,7 @@ class Activity < ApplicationRecord
     return nil if start.nil? || self.end.nil?
 
     loc = I18n.locale if loc.nil?
-    description = activity_url() ++ "\n" ++ (loc == :nl ? description_nl : description_en)
+    description = activity_url + "\n" + (loc == :nl ? description_nl : description_en)
     uri_name = URI.encode_www_form_component(name)
     uri_description = URI.encode_www_form_component(description)
     uri_location = URI.encode_www_form_component(location)
@@ -390,7 +390,7 @@ class Activity < ApplicationRecord
                   datetime: gen_time_string(loc),
                   location: location,
                   price: pc,
-                  url: activity_url(),
+                  url: activity_url,
                   description: loc == :nl ? description_nl : description_en,
                   locale: loc)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -356,12 +356,16 @@ class Activity < ApplicationRecord
     end
   end
 
+  def activity_url
+    return "https://koala.svsticky.nl/activities/#{ id }"
+  end
+
   # pass along locale default to nil
   def google_event(loc = nil)
     return nil if start.nil? || self.end.nil?
 
     loc = I18n.locale if loc.nil?
-    description = loc == :nl ? description_nl : description_en
+    description = activity_url() ++ "\n" ++ (loc == :nl ? description_nl : description_en)
     uri_name = URI.encode_www_form_component(name)
     uri_description = URI.encode_www_form_component(description)
     uri_location = URI.encode_www_form_component(location)
@@ -386,7 +390,7 @@ class Activity < ApplicationRecord
                   datetime: gen_time_string(loc),
                   location: location,
                   price: pc,
-                  url: "https://koala.svsticky.nl/activities/#{ id }",
+                  url: activity_url(),
                   description: loc == :nl ? description_nl : description_en,
                   locale: loc)
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -365,7 +365,7 @@ class Activity < ApplicationRecord
     return nil if start.nil? || self.end.nil?
 
     loc = I18n.locale if loc.nil?
-    description = "#{activity_url}\n#{loc == :nl ? description_nl : description_en}"
+    description = "#{activity_url}\n\n#{loc == :nl ? description_nl : description_en}"
     uri_name = URI.encode_www_form_component(name)
     uri_description = URI.encode_www_form_component(description)
     uri_location = URI.encode_www_form_component(location)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -365,7 +365,7 @@ class Activity < ApplicationRecord
     return nil if start.nil? || self.end.nil?
 
     loc = I18n.locale if loc.nil?
-    description = "#{activity_url}\n\n#{loc == :nl ? description_nl : description_en}"
+    description = "#{ activity_url }\n\n#{ loc == :nl ? description_nl : description_en }"
     uri_name = URI.encode_www_form_component(name)
     uri_description = URI.encode_www_form_component(description)
     uri_location = URI.encode_www_form_component(location)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -365,7 +365,7 @@ class Activity < ApplicationRecord
     return nil if start.nil? || self.end.nil?
 
     loc = I18n.locale if loc.nil?
-    description = activity_url + "\n" + (loc == :nl ? description_nl : description_en)
+    description = "#{activity_url}\n#{loc == :nl ? description_nl : description_en}"
     uri_name = URI.encode_www_form_component(name)
     uri_description = URI.encode_www_form_component(description)
     uri_location = URI.encode_www_form_component(location)


### PR DESCRIPTION
When adding an activity to your calendar through the new link (as mentioned in #1045), the link to the activity is not included in the description of the activity.

I can't run koala locally as of now, but I believe this syntax might be correct. If not, please correct it :)