### PR TITLE
Automatically add opened PRs to project

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -4,10 +4,13 @@ on:
   issues:
     types:
       - opened
+  pull_request:
+    types:
+      - opened
 
 jobs:
   add-to-project:
-    name: Add opened issue to CommITCrowd project
+    name: Add opened issue or PR to CommITCrowd project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0


### PR DESCRIPTION
This already happens to issues. Now PR's should be included as well. Not tested, but should work.