### PR TITLE
Add text field to add a member as reservist to an activity

### DIFF
--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -4,7 +4,7 @@ class Admin::ParticipantsController < ApplicationController
     @participant = Participant.new(
       member: Member.find_by(id: params[:member]),
       activity: Activity.find_by(id: params[:activity_id]),
-      reservist: params[:reservist] || false,
+      reservist: params[:reservist] || false
     )
 
     impressionist(@participant) if @participant.save

--- a/app/controllers/admin/participants_controller.rb
+++ b/app/controllers/admin/participants_controller.rb
@@ -3,7 +3,8 @@ class Admin::ParticipantsController < ApplicationController
   def create
     @participant = Participant.new(
       member: Member.find_by(id: params[:member]),
-      activity: Activity.find_by(id: params[:activity_id])
+      activity: Activity.find_by(id: params[:activity_id]),
+      reservist: params[:reservist] || false,
     )
 
     impressionist(@participant) if @participant.save

--- a/app/javascript/src/admin/activities.js
+++ b/app/javascript/src/admin/activities.js
@@ -394,7 +394,7 @@ $(document).on("ready page:load turbolinks:load", function () {
     .find("input#participant-reservist")
     .search()
     .on("selected", function (event, id) {
-        participant.enroll($("#reservists-table").attr("data-id"), id, true);
+      participant.enroll($("#reservists-table").attr("data-id"), id, true);
     });
 
   posterHandlers();

--- a/app/javascript/src/admin/activities.js
+++ b/app/javascript/src/admin/activities.js
@@ -358,12 +358,13 @@ var participant = {
       });
   },
 
-  enroll(activity_id, member_id) {
+  enroll(activity_id, member_id, reservist = false) {
     $.ajax({
       url: "/activities/" + activity_id + "/participants",
       type: "POST",
       data: {
         member: member_id,
+        reservist: reservist,
       },
     })
       .done(function (data) {
@@ -389,7 +390,15 @@ $(document).on("ready page:load turbolinks:load", function () {
       participant.enroll($("#participants-table").attr("data-id"), id);
     });
 
+  $("#participants")
+    .find("input#participant-reservist")
+    .search()
+    .on("selected", function (event, id) {
+        participant.enroll($("#reservists-table").attr("data-id"), id, true);
+    });
+
   posterHandlers();
+
   if (window.location.href.indexOf("summary_only") !== -1) {
     makeTableCollapsable();
     addCopyTableCallBack();

--- a/app/views/admin/activities/show.html.haml
+++ b/app/views/admin/activities/show.html.haml
@@ -31,7 +31,6 @@
             %span#pricesum= " / €"+(number_with_precision(@activity.price_sum, :precision => 2) || 0)
             %span#paidsum= "€"+(number_with_precision(@activity.paid_sum, :precision => 2) || 0)
 
-
           %template#attendee-table-row
             = render 'admin/activities/partials/attendee_table_row', participant: Participant.new(activity: @activity, member: Member.new)
           %table#participants-table.table.table-striped.table-linked{ :data => { 'id' => @activity.id }}
@@ -50,7 +49,7 @@
                     = I18n.t('activerecord.attributes.activity.member_is_spare')
             %tbody
               - [@attendees.map {|participant| {"entity" => participant, "is_reservist" => false}},
-                 @reservists.map{| reservist | {"entity" => reservist,   "is_reservist" => true}}].reduce([], :concat).each do |member|
+                 @reservists.map{|reservist| {"entity" => reservist, "is_reservist" => true}}].reduce([], :concat).each do |member|
                 - if !@is_summarized.nil?
                   = render 'admin/activities/partials/attendee_table_row_summary', member: member
                 - elsif !member["is_reservist"]
@@ -124,3 +123,15 @@
                           %i.fa.fa-fw.fa-plus
                         %button.btn.btn-default.destroy
                           %i.fa.fa-fw.fa-trash
+                            %tr
+
+                -# Add member to reservist participants
+                %tr
+                  %td{ :style => 'position: relative;'}
+                    %input#participant-reservist.col-md-11{ :style => 'margin-left: -3px;', :tabindex => '-1' }
+                    %ul.dropdown-menu.col-md-11
+                  %td{ :style => 'text-align: left;' }
+                    - if !@activity.price.nil?
+                      %span= number_to_currency(@activity.price, :unit => '€')
+                  %td
+


### PR DESCRIPTION
Due to whatever reason, the member shows up in the non-reservists table directly after adding them, this is a frontend thing. Refreshing fixes it. LGTM.