### PR TITLE
Remove mongoose balance from the member home page

### DIFF
--- a/app/views/members/home/index.html.haml
+++ b/app/views/members/home/index.html.haml
@@ -27,15 +27,15 @@
     = render partial: 'layouts/partials/pagination', locals: {pagy: @pagination}
 
   .col-lg-6.float-right
-    - unless @balance.blank?
-      .card.card-box
-        .row.no-gutters
-          .col.bg-success.card-body
-            %i.fa.fa-shopping-cart.fa-5x
-          .col.card-body
-            %p.size-h2
-              = number_to_currency( @balance.balance, :unit => '€' )
-            %p.text-muted.text-center= I18n.t('activerecord.models.checkout_balance')
+    -# - unless @balance.blank?
+    -#   .card.card-box
+    -#     .row.no-gutters
+    -#       .col.bg-success.card-body
+    -#         %i.fa.fa-shopping-cart.fa-5x
+    -#       .col.card-body
+    -#         %p.size-h2
+    -#           = number_to_currency( @balance.balance, :unit => '€' )
+    -#         %p.text-muted.text-center= I18n.t('activerecord.models.checkout_balance')
 
     .card.card-box
       .row.no-gutters


### PR DESCRIPTION
The balance is not correct, and serves no purpose since the decoupling of Mongoose from Koala