### PR TITLE
More hotkeys

### DIFF
--- a/app/javascript/src/admin/main.js
+++ b/app/javascript/src/admin/main.js
@@ -16,7 +16,12 @@ $(document).on("ready page:load turbolinks:load", function () {
   });
 
   $(window).on("keydown", (evt) => {
-    if ($("input").is(":focus")) {
+    // <input>, <textarea>, or the mailer input field
+    if (
+      $("input").is(":focus") ||
+      $("textarea").is(":focus") ||
+      document.getElementById("editor")?.contains(document.activeElement)
+    ) {
       // Cancel if any inputs are selected
       return;
     }

--- a/app/javascript/src/admin/members.js
+++ b/app/javascript/src/admin/members.js
@@ -13,26 +13,42 @@ $(document).on("ready page:load turbolinks:load", function () {
   setup_intl_tel_input();
 
   $(window).on("keydown", (evt) => {
-    if ($("input").is(":focus")) {
+    // <input>, <textarea>, or the mailer input field
+    if (
+      $("input").is(":focus") ||
+      $("textarea").is(":focus") ||
+      document.getElementById("editor")?.contains(document.activeElement)
+    ) {
       // Cancel if any inputs are selected
       return;
     }
 
-    // Click the edit button on the 'e' keypress
+    // Edit member
     if (evt.key === "e") {
-      // Do something
       document.getElementById("member-btn-edit")?.click();
+    }
+
+    // Cancel editing
+    if (evt.key === "Escape" || (evt.key === "Delete" && evt.ctrlKey)) {
+      document.getElementById("admin-member-edit-btn-cancel")?.click();
       return;
     }
 
-    // Cancel editing on Ctrl+Esc
-    if (evt.key === "Escape" && evt.ctrlKey) {
-      document.getElementById("admin-member-edit-btn-cancel")?.click();
-    }
-
-    // Save editing user on ctrl+enter
+    // Save editing
     if (evt.key === "Enter" && evt.ctrlKey) {
       document.getElementById("admin-member-edit-btn-save")?.click();
+    }
+
+    // Set status of first study to 'Afgestudeerd'
+    if (evt.key === "a" && !evt.ctrlKey) {
+      $($(".educ-status select")[0]).val("inactive").change();
+    }
+
+    // Set status of second study to 'Afgestudeerd'
+    if (evt.key === "a" && evt.ctrlKey) {
+      evt.preventDefault();
+
+      $($(".educ-status select")[1]).val("inactive").change();
     }
   });
 

--- a/app/views/admin/members/edit.html.haml
+++ b/app/views/admin/members/edit.html.haml
@@ -112,7 +112,7 @@
                           .ui-select
                             = fs.select :study_id, options_for_select(Study.all.map{|s| [I18n.t(s.code.downcase, scope: 'activerecord.attributes.study.names'), s.id]}, education.study_id), :include_blank => "--"
                         .col-md-6
-                          .ui-select
+                          .ui-select.educ-status
                             = fs.select :status, options_for_select(Education.statuses.map{ |name, id| [I18n.t(name, scope: 'activerecord.attributes.education.status'), name]}, education.status)
                       .row
                         .col-md-6


### PR DESCRIPTION
## Changes
Fix: Dont focus the search bar if the mailer or a textarea is selected
Add: When editing a member, `a` and `ctrl+a` to set the first or second study to 'Afgestudeerd', respectively