### PR TITLE
Removed second empty KOALA_DOMAIN from sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -75,16 +75,13 @@ MAILCHIMP_TEACHER_ID=
 # Used for when testing webhooks
 NGROK_HOST=http
 
-# Hostname of where Koala is running, like https://koala.svsticky.nl or http://koala.rails.local:3000
-KOALA_DOMAIN=
-
 # MOLLIE credentials for the iDEAL integration.
 MOLLIE_DOMAIN=https://api.mollie.nl
 MOLLIE_VERSION=v1
 MOLLIE_TOKEN=
 
-
 # Secret for error reporting.
 SENTRY_DSN=
 
+# Endpoint for catching webhooks using ngrok
 WEBHOOK_URLS=http://localhost:8000/catchwebhook


### PR DESCRIPTION
The empty `KOALA_DOMAIN` variable caused issues in the seeding of the payments, as 'ideal' transactions require this value to be set. This caused the database to be only be seeded with 'pin' transactions.