### PR TITLE
In dark mode, use the coloured logo as well

### DIFF
--- a/app/views/layouts/doorkeeper.html.haml
+++ b/app/views/layouts/doorkeeper.html.haml
@@ -19,7 +19,7 @@
   %body.h-full.flex.flex-col.bg-gray-100.dark:bg-gray-900
     .flex.flex-col.flex-grow.justify-center
       %img.w-64.mx-auto.p-4.dark:hidden{src:"https://public.svsticky.nl/logos/logo_compact_outline_kleur.svg"}
-      %img.w-64.mx-auto.p-4.hidden.dark:block{src:"https://public.svsticky.nl/logos/logo_compact_outline_wit.svg"}
+      %img.w-64.mx-auto.p-4.hidden.dark:block{src:"https://public.svsticky.nl/logos/logo_compact_outline_wit_kleur.svg"}
 
       .shadow.px-10.py-4.rounded-md.bg-white.mx-auto.dark:bg-gray-800.dark
 


### PR DESCRIPTION
On the login page, in light mode we used the coloured logo, but in dark mode we used the white logo (due to the lack of a white *and* coloured logo). I've added this logo to public.svsticky.nl, and the login page now uses it.