### PR TITLE
Changed English translation of VoelJeVeilig to 'Feel Safe'

### DIFF
--- a/config/locales/members.en.yml
+++ b/config/locales/members.en.yml
@@ -93,7 +93,7 @@ en:
       payments: Payments
       pictures: Pictures
       vacancies: Vacancies
-      voeljeveilig: VoelJeVeilig
+      voeljeveilig: Feel Safe
       wiki: Stickypedia
     payments:
       mongoose:


### PR DESCRIPTION
As per [this](https://svsticky.nl/en-US/vereniging/vertrouwenspersonen) page, the English translation of 'Voel Je Veilig' is 'Feel Safe'.

In my opinion, this should be consistent.