### PR TITLE
fixed discord url yay

### DIFF
--- a/app/views/layouts/members.html.haml
+++ b/app/views/layouts/members.html.haml
@@ -84,7 +84,7 @@
               = link_to "https://github.com/svsticky/", :class => 'list-group-item list-group-item-action' do
                 %span= I18n.t('members.navigation.github')
                 %i.fab.fa-github
-              = link_to "https://svsticky.nl/discord/", :class => 'list-group-item list-group-item-action' do
+              = link_to "https://svsticky.nl/discord", :class => 'list-group-item list-group-item-action' do
                 %span= I18n.t('members.navigation.discord')
                 %i.fab.fa-discord
               = link_to "https://wiki.svsticky.nl/", :class => 'list-group-item list-group-item-action' do


### PR DESCRIPTION
# Current behaviour
trailing / in https://svsticky.nl/discord` routes to a 404, so no viewing discord for you when pressing the discord button on koala.svsticky.nl

# expected behaviour
pressing the discord button routes you to the discord of sv sticky

# fix:
remove trailing comma