### PR TITLE
fix: include other signup domains

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -141,7 +141,7 @@ only accessible from the computer where you're running the server.
 In order to have the server actually work, you'll need to run this command once:
 
 ```console
-echo "127.0.0.1    koala.rails.local members.rails.local leden.rails.local wordlid.rails.local" | sudo tee -a /etc/hosts
+echo "127.0.0.1    koala.rails.local members.rails.local leden.rails.local wordlid.rails.local signup.rails.local join.rails.local" | sudo tee -a /etc/hosts
 ```
 
 After this, when the server is running, you can open

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
 
   config.hosts << 'koala.rails.local'
   config.hosts << 'wordlid.rails.local'
+  config.hosts << 'signup.rails.local'
+  config.hosts << 'join.rails.local'
   config.hosts << 'leden.rails.local'
   config.hosts << 'members.rails.local'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,6 +94,8 @@ Rails.application.configure do
 
   config.hosts << 'koala.svsticky.nl'
   config.hosts << 'wordlid.svsticky.nl'
+  config.hosts << 'signup.svsticky.nl'
+  config.hosts << 'join.svsticky.nl'
   config.hosts << 'leden.svsticky.nl'
   config.hosts << 'members.svsticky.nl'
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -95,6 +95,8 @@ Rails.application.configure do
 
   config.hosts << "koala.dev.svsticky.nl"
   config.hosts << "wordlid.dev.svsticky.nl"
+  config.hosts << "signup.dev.svsticky.nl"
+  config.hosts << "join.dev.svsticky.nl"
   config.hosts << "leden.dev.svsticky.nl"
   config.hosts << "members.dev.svsticky.nl"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   use_doorkeeper_openid_connect
 
-  constraints subdomain: ['wordlid', 'wordlid.dev'] do
+  constraints subdomain: ['wordlid', 'wordlid.dev', 'signup', 'signup.dev', 'join', 'join.dev'] do
     scope module: 'public' do
       get  '/', to: 'home#index', as: 'public'
       post '/', to: 'home#create'


### PR DESCRIPTION
Koala was not aware of our new domains, and as such does not accept authentication tokens from those domains.

Starting a local version of those domains should now also be possible.