### PR TITLE
fix: new member activation link pointing to confirmation url

### DIFF
--- a/config/locales/mailings.en.yml
+++ b/config/locales/mailings.en.yml
@@ -4,15 +4,15 @@ en:
     best_regards: Best regards,
     checkout:
       confirm_card: Confirm card
-      confirm_card_link: Confirme Checkout card for your account at Study association Sticky by going to %{confirm_url}.
+      confirm_card_link: Confirm Checkout card for your account at Study association Sticky by going to %{confirm_url}.
       confirmation_instructions: 'Confirm your card for your Checkout account with Study association Sticky by clicking the following button:'
       subject: Confirm Checkout card
     confirm: Are you sure you want to sent this email?
     devise:
       activation_instructions:
-        about_sticky: 'You can go to Sticky for everything that you as Computer Science, Information Science or Game technology need! As you might have noticed already, you can always score free coffee and a cookie in our room (BBG 2,81) or some other other drink/snack. There will always be someone of the board present in the room who can answer all your questions. Besides this place to chill during breaks or in between lectures, we also organise a whole lot of wildly awesome activities. These activities These activities are always aligned to one of the three corner stones of Sticky: Education, Business and Sociability.'
-        account_activation_instructions: Activate your account by clicking the button below
-        account_activation_link: Activate your account for our member system by going to %{url}.
+        about_sticky: 'You can go to Sticky for everything that you as Computer Science, Information Science or Game technology student need! As you might have noticed already, you can always score free coffee and a cookie in our room (BBG 2,81) or some other other drink/snack. There will always be someone of the board present in the room who can answer all your questions. Besides this place to chill during breaks or in between lectures, we also organise a whole lot of wildly awesome activities. These activities These activities are always aligned to one of the three corner stones of Sticky: Education, Business and Sociability.'
+        account_activation_instructions: Activate your account by clicking the button below.
+        account_activation_link: Activate your account for our member system by going to %{url}. NOTE if this url does not work, replace 'confirmation' at the end of the url with 'activate'! Why this can go wrong, you ask? Long story.
         activate_account: Activate account
         activity_updates_html: 'Do you always want to stay informed about these activities? Follow us on %{instagram_page_link_start} the Sticky-members Instagram%{link_end} and on %{linkedin_page_link_start} LinkedId%{link_end}! Aside from that, you can find all information that you could ever want on our website: %{sticky_site_link_start} svsticky.nl%{link_end}. You can also join our %{whatsapp_promo_link_start} WhatsApp promotion channel%{link_end} to be notified about upcoming activities!'
         and_now: And now?
@@ -24,7 +24,7 @@ en:
             description_html: We organise helper days, workshops and information meetings to support you with your study. The Commissioner for Education is your point of contact for anything to do with education and it's quality. You can conveniently buy the books you need and have them delivered at your home at the %{books_page_link_start} svsticky.nl/boeken%{link_end}!
             name: Education
           sociability:
-            description: Besides the study- and carrier-related activities stated above, we also organise many simply sociable activities, like the weekly drinks!
+            description: Besides the study- and career-related activities stated above, we also organise many simply sociable activities, like the weekly drinks!
             name: Sociability
         reception_justification: You are receiving this e-mail, because you signed up for our mighty beautiful study association! At the end of this mail you will find a button to activate your account in our members portal. You could also skip this gorgeous introduction talk en scroll down immediately. We won't see that anyway (or will we?).
         see_you_soon: See you soon!
@@ -32,7 +32,7 @@ en:
         wrap_up_html: Curious about which activities we will soon organize? You can find more information in our member portal, %{koala_link_start} Koala%{link_end}, and you can enroll there too! In this member portal you can also edit your profile.
       changed_instructions:
         changed_email: Emailaddress changed
-        inform_change_text: Your emailaddress is changed to %{new_email}. Please contact us as soon as possible (by replying to this email) if this change was not done by you.
+        inform_change_text: Your e-mail address has been changed to %{new_email}. Please contact us as soon as possible (by replying to this email) if this change was not done by you.
       confirmation_instructions:
         activate_account: Activate account
         button_instructions: Confirm your e-mail address for your Sticky account by clicking the button below!

--- a/config/locales/mailings.nl.yml
+++ b/config/locales/mailings.nl.yml
@@ -12,7 +12,7 @@ nl:
       activation_instructions:
         about_sticky: 'Bij Sticky kun je terecht voor alles wat jij als student Informatica, Informatiekunde of Gametechnologie nodig hebt! Zoals je wellicht al vernomen hebt, kun je altijd een gratis kop koffie en een koekje scoren in onze kamer (BBG 2.81), of een ander(e) drankje/snack. In de kamer is ook altijd iemand van het bestuur aanwezig om al jouw vragen te beantwoorden. Naast deze plek om te chillen tijdens pauzes of tussen de colleges door, organiseren we ook nog eens enorm veel woestgave activiteiten! Deze activiteiten zijn altijd in lijn met één van de drie pijlers van Sticky: onderwijs, bedrijfsleven en gezelligheid.'
         account_activation_instructions: 'Activeer je account door op onderstaande knop te klikken:'
-        account_activation_link: Activeer je account voor ons ledenbeheersysteem door naar %{url} te gaan.
+        account_activation_link: Activeer je account voor ons ledenbeheersysteem door naar %{url} te gaan. LET OP! Als deze link niet werkt, vervang dan 'confirmation' aan het einde van de link met 'activate'! Waarom dit soms nodig is? Lang verhaal.
         activate_account: Activeer account
         activity_updates_html: 'Altijd op de hoogte blijven van deze activiteiten? Volg ons op %{instagram_page_link_start} Instagram%{link_end} en op %{linkedin_page_link_start} LinkedIn%{link_end}! Daarnaast vind je alle informatie die je ooit had kunnen wensen op onze website: %{sticky_site_link_start} svsticky.nl%{link_end}. Je kunt ook lid worden van onze %{whatsapp_promo_link_start} WhatsApp community%{link_end} om altijd op de hoogte gehouden te worden van aankomende activiteiten!'
         and_now: En nu?


### PR DESCRIPTION
A little is better than nothing. Me and Tobias have now tried to solve the bug's cause, in vein. Thus, here is a workaround.

The intention is that a noticable explenation is present in the email, explaining what the user should do if they have the incorrect link.

I have not tested what this looks like, for I don't know how to test emails in staging environments (non are send).

@TobiasDeBruijn do you agree?
@olafboekholt are the included instructions correct?