### PR TITLE
feat: remove old registration form

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,46 +5,6 @@ class Users::RegistrationsController < ActionController::Base
 
   layout 'doorkeeper'
 
-  def new
-    @user = User.new
-    render('devise/registrations/new')
-  end
-
-  def create
-    @user = User.find_by(email: sign_up_params[:email])
-    if @user && !@user.confirmed_at
-      @user.resend_confirmation!(:confirmation_instructions)
-      flash[:notice] = I18n.t('devise.registrations.already_signed_up_unconfirmed')
-
-      redirect_to(:new_user_session)
-      return
-    elsif @user&.confirmed_at
-      @user.send_reset_password_instructions
-      flash[:notice] = I18n.t('devise.passwords.send_instructions')
-
-      redirect_to(:new_user_session)
-      return
-    end
-
-    @user = User.new(sign_up_params)
-    @user.credentials = Member.find_by(email: sign_up_params[:email])
-
-    flash[:alert] = nil
-
-    if @user.credentials.nil?
-      flash[:alert] = I18n.t(:not_found_in_database, scope: 'devise.registrations')
-      render('devise/registrations/new')
-      return
-    end
-
-    if @user.save
-      flash[:notice] = I18n.t(:signed_up_but_unconfirmed, scope: 'devise.registrations')
-      redirect_to(:new_user_session)
-    else
-      render('devise/registrations/new')
-    end
-  end
-
   # show page for first confirmation setting a new password for new enrollments
   def edit
     @user = User.find_by(confirmation_token: params[:confirmation_token])

--- a/app/views/devise/confirmations/edit.html.haml
+++ b/app/views/devise/confirmations/edit.html.haml
@@ -47,8 +47,4 @@
         = f.submit t('devise.confirmations.activate_account'), :class => 'btn btn-primary btn-block'
         -# i18n todo
 
-.row
-  .text-center.dark:text-white
-    = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
-    |
-    = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
+= render 'devise/partials/form_footer'

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -29,8 +29,4 @@
       .form-group
         = f.submit I18n.t 'devise.confirmations.new.submit', :class => 'btn btn-primary btn-block'
 
-.row
-  .text-center.mx-auto.dark:text-white
-    = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
-    |
-    = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path
+= render 'devise/partials/form_footer'

--- a/app/views/devise/confirmations/show.html.haml
+++ b/app/views/devise/confirmations/show.html.haml
@@ -38,8 +38,4 @@
         = f.hidden_field :confirmation_token, value: @user.confirmation_token
         = f.submit t('devise.confirmations.new.submit'), :class => 'btn btn-primary btn-block'
 
-.row
-  .text-center.dark:text-white
-    = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
-    |
-    = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path
+= render 'devise/partials/form_footer'

--- a/app/views/devise/partials/_form_footer.html.haml
+++ b/app/views/devise/partials/_form_footer.html.haml
@@ -1,0 +1,5 @@
+.row
+  .text-center.mx-auto.dark:text-white
+    = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
+    |
+    = link_to (I18n.t 'devise.registrations.sign_up'), "https://wordlid.svsticky.nl"

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -39,8 +39,4 @@
       .form-group
         = f.submit I18n.t('devise.passwords.edit.change_password'), :class => 'btn btn-primary btn-block'
 
-.row
-  .text-center.mx-auto.dark:text-white
-    = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
-    |
-    = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path
+= render 'devise/partials/form_footer'

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -33,8 +33,4 @@
       .form-group
         = f.submit I18n.t('devise.passwords.new.submit'), :class => 'btn btn-primary btn-block'
 
-.row
-  .text-center.mx-auto.dark:text-white
-    = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
-    |
-    = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path
+= render 'devise/partials/form_footer'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -44,8 +44,4 @@
       .form-group
         = f.submit I18n.t('devise.registrations.new.submit'), :class => 'btn btn-primary btn-block'
 
-.row
-  .text-center.mx-auto.dark:text-white
-    = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
-    |
-    = link_to (I18n.t 'devise.registrations.login'), new_user_session_path
+= render 'devise/partials/form_footer'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -37,8 +37,4 @@
       .form-group
         = f.submit I18n.t('devise.sessions.new.sign_in'), :class => 'btn btn-primary btn-block'
 
-.row
-  .text-center.mx-auto.dark:text-white
-    = link_to (I18n.t 'devise.registrations.password_recovery'), new_user_password_path
-    |
-    = link_to (I18n.t 'devise.registrations.sign_up'), new_registration_path
+= render 'devise/partials/form_footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,10 +45,6 @@ Rails.application.routes.draw do
       passwords: 'users/passwords'
     }
 
-    # create account using a member's email
-    get     'sign_up',      to: 'users/registrations#new', as: :new_registration
-    post    'sign_up',      to: 'users/registrations#create'
-
     # update account with password after receiving invite
     get     'activate',     to: 'users/registrations#edit', as: :new_member_confirmation
     post    'activate',     to: 'users/registrations#update', as: :new_member_confirm


### PR DESCRIPTION
The old registration form causes a lot of confusion among people who want to sign up for sticky. Since we only want to allow signing up from wordlid.svsticky.nl, I reckon it is wise to remove the old registration form. The additional bonus is that we remove one source of sending emails with the wrong activation link.