### PR TITLE
fix timezone in personal data download

### DIFF
--- a/app/views/members/home/download.html.haml
+++ b/app/views/members/home/download.html.haml
@@ -297,6 +297,6 @@
 
       %span.footer
         = I18n.t('members.home.edit.download.generated')
-        = I18n.l(Time.now)
+        = I18n.l(Time.zone.now)
         = I18n.t('members.home.edit.download.for')
         = @member.name


### PR DESCRIPTION
in "edit profile" -> "download personal data", all the way at the bottom, it showed the time of downloading in UTC. Changed this to the local timezone (CET / CEST).