### PR TITLE
Fix: include start_time in activity sort order

### DIFF
--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -65,7 +65,7 @@ https://koala.svsticky.nl/activities/#{ ac.id }
       impressionist(@activity)
       redirect_to(@activity)
     else
-      @activities = Activity.all.order(start_date: :desc)
+      @activities = Activity.all.order(start_date: :desc, start_time: :desc)
       @years = (Activity.take(1).first.start_date.year..Date.today.study_year).map do |year|
         ["#{ year }-#{ year + 1 }", year]
       end.reverse

--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -3,7 +3,7 @@ class Admin::ActivitiesController < ApplicationController
   impressionist actions: [:update, :destroy]
 
   def index
-    @activities = Activity.study_year(params['year']).order(start_date: :desc)
+    @activities = Activity.study_year(params['year']).order(start_date: :desc, start_time: :desc)
     @years = (Activity.take(1).first.start_date.year..Date.today.study_year).map do |year|
       ["#{ year }-#{ year + 1 }", year]
     end.reverse
@@ -22,7 +22,7 @@ class Admin::ActivitiesController < ApplicationController
     res = "*#{ t('admin.activities.weekoverzicht.header', locale: locale) }*\n\n"
     res += (0..4).map do |n|
       week_day = week_start + n.days
-      acs = Activity.where(start_date: week_day, include_in_weekoverzicht: true).all
+      acs = Activity.where(start_date: week_day, include_in_weekoverzicht: true).all.order(start_time: :asc)
       header = "*#{ l(week_day, format: '%A', locale: locale).capitalize }*"
       if acs.empty?
         "#{ header }\n#{ t('admin.activities.no_activity', locale: locale) }\n"


### PR DESCRIPTION
Closes #1215.
Included start_time in the sorting arguments, instead of only start_date.